### PR TITLE
chore: swap blockenv values instead of cloning 

### DIFF
--- a/crates/evm/src/eth.rs
+++ b/crates/evm/src/eth.rs
@@ -66,16 +66,16 @@ impl<EXT, DB: Database> Evm for EthEvm<'_, EXT, DB> {
         let mut basefee = U256::ZERO;
 
         // ensure the block gas limit is >= the tx
-        std::mem::swap(&mut self.block_mut().gas_limit, &mut gas_limit);
+        core::mem::swap(&mut self.block_mut().gas_limit, &mut gas_limit);
         // disable the base fee check for this call by setting the base fee to zero
-        std::mem::swap(&mut self.block_mut().basefee, &mut basefee);
+        core::mem::swap(&mut self.block_mut().basefee, &mut basefee);
 
         let res = self.0.transact();
 
         // swap back to the previous gas limit
-        std::mem::swap(&mut self.block_mut().gas_limit, &mut gas_limit);
+        core::mem::swap(&mut self.block_mut().gas_limit, &mut gas_limit);
         // swap back to the previous base fee
-        std::mem::swap(&mut self.block_mut().basefee, &mut basefee);
+        core::mem::swap(&mut self.block_mut().basefee, &mut basefee);
 
         res
     }

--- a/crates/evm/src/eth.rs
+++ b/crates/evm/src/eth.rs
@@ -62,18 +62,20 @@ impl<EXT, DB: Database> Evm for EthEvm<'_, EXT, DB> {
 
         *self.tx_mut() = tx_env;
 
-        let prev_block_env = self.block().clone();
+        let mut gas_limit = U256::from(self.tx().gas_limit);
+        let mut basefee = U256::ZERO;
 
         // ensure the block gas limit is >= the tx
-        self.block_mut().gas_limit = U256::from(self.tx().gas_limit);
-
+        std::mem::swap(&mut self.block_mut().gas_limit, &mut gas_limit);
         // disable the base fee check for this call by setting the base fee to zero
-        self.block_mut().basefee = U256::ZERO;
+        std::mem::swap(&mut self.block_mut().basefee, &mut basefee);
 
         let res = self.0.transact();
 
-        // re-set the block env
-        *self.block_mut() = prev_block_env;
+        // swap back to the previous gas limit
+        std::mem::swap(&mut self.block_mut().gas_limit, &mut gas_limit);
+        // swap back to the previous base fee
+        std::mem::swap(&mut self.block_mut().basefee, &mut basefee);
 
         res
     }

--- a/crates/op-evm/src/lib.rs
+++ b/crates/op-evm/src/lib.rs
@@ -82,18 +82,20 @@ impl<EXT, DB: Database> Evm for OpEvm<'_, EXT, DB> {
 
         *self.tx_mut() = tx_env;
 
-        let prev_block_env = self.block().clone();
+        let mut gas_limit = U256::from(self.tx().gas_limit);
+        let mut basefee = U256::ZERO;
 
         // ensure the block gas limit is >= the tx
-        self.block_mut().gas_limit = U256::from(self.tx().gas_limit);
-
+        core::mem::swap(&mut self.block_mut().gas_limit, &mut gas_limit);
         // disable the base fee check for this call by setting the base fee to zero
-        self.block_mut().basefee = U256::ZERO;
+        core::mem::swap(&mut self.block_mut().basefee, &mut basefee);
 
         let res = self.0.transact();
 
-        // re-set the block env
-        *self.block_mut() = prev_block_env;
+        // swap back to the previous gas limit
+        core::mem::swap(&mut self.block_mut().gas_limit, &mut gas_limit);
+        // swap back to the previous base fee
+        core::mem::swap(&mut self.block_mut().basefee, &mut basefee);
 
         res
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Closes #9

## Solution

swaps the individual blockenv values instead of cloning the entire block env.

## PR Checklist

- [ ] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
