### PR TITLE
feat: `TxEnv` conversion traits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,8 +41,8 @@ alloy-op-evm = { version = "0.1.0", path = "crates/op-evm", default-features = f
 # alloy
 alloy-eip2124 = { version = "0.1", default-features = false }
 alloy-chains = { version = "0.1.32", default-features = false }
-alloy-eips = { version = "0.8", default-features = false }
-alloy-consensus = { version = "0.8", default-features = false }
+alloy-eips = { version = "0.11", default-features = false }
+alloy-consensus = { version = "0.11", default-features = false }
 alloy-primitives = { version = "0.8", default-features = false }
 
 # revm

--- a/crates/evm/Cargo.toml
+++ b/crates/evm/Cargo.toml
@@ -14,10 +14,11 @@ repository.workspace = true
 workspace = true
 
 [dependencies]
+alloy-consensus.workspace = true
 alloy-primitives.workspace = true
+
 revm.workspace = true
 revm-optimism = { workspace = true, optional = true }
-
 
 [features]
 default = ["std"]

--- a/crates/evm/src/eth.rs
+++ b/crates/evm/src/eth.rs
@@ -95,7 +95,7 @@ where
         &self.block
     }
 
-    fn transact(&mut self, tx: Self::Tx) -> Result<ResultAndState, Self::Error> {
+    fn transact_raw(&mut self, tx: Self::Tx) -> Result<ResultAndState, Self::Error> {
         if self.inspect {
             self.inner.set_tx(tx);
             self.inner.inspect_previous()

--- a/crates/evm/src/evm.rs
+++ b/crates/evm/src/evm.rs
@@ -27,6 +27,10 @@ pub trait Evm {
     /// Database type held by the EVM.
     type DB;
     /// The transaction object that the EVM will execute.
+    ///
+    /// Implementations are expected to rely on a single entrypoint for transaction execution such
+    /// as [`revm::context::TxEnv`]. The actual set of valid inputs is not limited by allowing to
+    /// provide any [`IntoTxEnv`] implementation for [`Evm::transact`] method.
     type Tx;
     /// Error type returned by EVM. Contains either errors related to invalid transactions or
     /// internal irrecoverable execution errors.

--- a/crates/evm/src/evm.rs
+++ b/crates/evm/src/evm.rs
@@ -1,6 +1,6 @@
 //! Abstraction over EVM.
 
-use crate::EvmError;
+use crate::{EvmError, IntoTxEnv};
 use alloy_primitives::{Address, Bytes};
 use core::error::Error;
 use revm::{
@@ -40,7 +40,19 @@ pub trait Evm {
     fn block(&self) -> &BlockEnv;
 
     /// Executes a transaction and returns the outcome.
-    fn transact(&mut self, tx: Self::Tx) -> Result<ResultAndState<Self::HaltReason>, Self::Error>;
+    fn transact_raw(
+        &mut self,
+        tx: Self::Tx,
+    ) -> Result<ResultAndState<Self::HaltReason>, Self::Error>;
+
+    /// Same as [`Evm::transact_raw`], but takes a [`IntoTxEnv`] implementation, thus allowing to
+    /// support transacting with an external type.
+    fn transact(
+        &mut self,
+        tx: impl IntoTxEnv<Self::Tx>,
+    ) -> Result<ResultAndState<Self::HaltReason>, Self::Error> {
+        self.transact_raw(tx.into_tx_env())
+    }
 
     /// Executes a system call.
     fn transact_system_call(
@@ -56,12 +68,12 @@ pub trait Evm {
     /// Executes a transaction and commits the state changes to the underlying database.
     fn transact_commit(
         &mut self,
-        tx_env: Self::Tx,
+        tx: impl IntoTxEnv<Self::Tx>,
     ) -> Result<ResultAndState<Self::HaltReason>, Self::Error>
     where
         Self::DB: DatabaseCommit,
     {
-        let result = self.transact(tx_env)?;
+        let result = self.transact(tx)?;
         self.db_mut().commit(result.state.clone());
 
         Ok(result)

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -18,3 +18,5 @@ pub mod env;
 pub use env::EvmEnv;
 pub mod error;
 pub use error::*;
+pub mod tx;
+pub use tx::*;

--- a/crates/evm/src/tx.rs
+++ b/crates/evm/src/tx.rs
@@ -1,0 +1,80 @@
+//! Abstraction of an executable transaction.
+
+use alloy_consensus::transaction::Recovered;
+use alloy_primitives::Address;
+use revm::context::TxEnv;
+
+/// Trait marking types that can be converted into a transaction environment.
+pub trait IntoTxEnv<TxEnv> {
+    /// Converts `self` into [`TxEnv`].
+    fn into_tx_env(self) -> TxEnv;
+}
+
+impl IntoTxEnv<Self> for TxEnv {
+    fn into_tx_env(self) -> Self {
+        self
+    }
+}
+
+#[cfg(feature = "op")]
+impl<T: revm::context::Transaction> IntoTxEnv<Self> for revm_optimism::OpTransaction<T> {
+    fn into_tx_env(self) -> Self {
+        self
+    }
+}
+
+/// Helper user-facing trait to allow implementing [`IntoTxEnv`] on instances of [`Recovered`].
+pub trait FromRecoveredTx<Tx> {
+    /// Builds a `TxEnv` from a transaction and a sender address.
+    fn from_recovered_tx(tx: &Tx, sender: Address) -> Self;
+}
+
+impl<TxEnv, T> FromRecoveredTx<&T> for TxEnv
+where
+    TxEnv: FromRecoveredTx<T>,
+{
+    fn from_recovered_tx(tx: &&T, sender: Address) -> Self {
+        TxEnv::from_recovered_tx(tx, sender)
+    }
+}
+
+impl<T, TxEnv: FromRecoveredTx<T>> IntoTxEnv<TxEnv> for Recovered<T> {
+    fn into_tx_env(self) -> TxEnv {
+        IntoTxEnv::into_tx_env(&self)
+    }
+}
+
+impl<T, TxEnv: FromRecoveredTx<T>> IntoTxEnv<TxEnv> for &Recovered<T> {
+    fn into_tx_env(self) -> TxEnv {
+        TxEnv::from_recovered_tx(self.tx(), self.signer())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct MyTxEnv;
+    struct MyTransaction;
+
+    impl IntoTxEnv<Self> for MyTxEnv {
+        fn into_tx_env(self) -> Self {
+            self
+        }
+    }
+
+    impl FromRecoveredTx<MyTransaction> for MyTxEnv {
+        fn from_recovered_tx(_tx: &MyTransaction, _sender: Address) -> Self {
+            Self
+        }
+    }
+
+    const fn assert_env<T: IntoTxEnv<MyTxEnv>>() {}
+
+    #[test]
+    const fn test_into_tx_env() {
+        assert_env::<MyTxEnv>();
+        assert_env::<&Recovered<MyTransaction>>();
+        assert_env::<&Recovered<&MyTransaction>>();
+    }
+}

--- a/crates/op-evm/src/lib.rs
+++ b/crates/op-evm/src/lib.rs
@@ -77,7 +77,10 @@ where
         &self.block
     }
 
-    fn transact(&mut self, tx: Self::Tx) -> Result<ResultAndState<Self::HaltReason>, Self::Error> {
+    fn transact_raw(
+        &mut self,
+        tx: Self::Tx,
+    ) -> Result<ResultAndState<Self::HaltReason>, Self::Error> {
         if self.inspect {
             self.inner.set_tx(tx);
             self.inner.inspect_previous()


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

ref https://github.com/paradigmxyz/reth/issues/14551

This PR introduces two traits:
- `IntoTxEnv` - core conversion trait performing simple conversion from a `Tx` to `TxEnv` type. `impl IntoTxEnv<Self::Tx>` is now used as input on `Evm::transact` allowing to extend a set of transaction environment types that can be passed 
- `FromRecoveredTx` - a helper trait to provide `IntoTxEnv` implementations for `Recovered<Tx>`

This should allow us to cover all of the usecase as all of `TxEnv`, `Recovered<Tx>`, `Recovered<&Tx>` are now valid inputs for Evm, and users are still free to define `IntoTxEnv` for any external types.

One required hack is that any Evm impl has to define for `IntoTxEnv<Self>` for the `Evm::Tx` which is not perfect but is not that bad generally as we already require similar `AsRef<Self>` implementations to be provided in reth

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
