### PR TITLE
refactor: do not clone state on `transact_commit`

### DIFF
--- a/crates/evm/src/evm.rs
+++ b/crates/evm/src/evm.rs
@@ -4,7 +4,7 @@ use crate::{EvmError, IntoTxEnv};
 use alloy_primitives::{Address, Bytes};
 use core::error::Error;
 use revm::{
-    context::BlockEnv,
+    context::{result::ExecutionResult, BlockEnv},
     context_interface::{
         result::{HaltReasonTr, ResultAndState},
         ContextTr,
@@ -73,12 +73,12 @@ pub trait Evm {
     fn transact_commit(
         &mut self,
         tx: impl IntoTxEnv<Self::Tx>,
-    ) -> Result<ResultAndState<Self::HaltReason>, Self::Error>
+    ) -> Result<ExecutionResult<Self::HaltReason>, Self::Error>
     where
         Self::DB: DatabaseCommit,
     {
-        let result = self.transact(tx)?;
-        self.db_mut().commit(result.state.clone());
+        let ResultAndState { result, state } = self.transact(tx)?;
+        self.db_mut().commit(state);
 
         Ok(result)
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

This clone is expensive and is not really needed as state is already accessible when calling `transact` and `commit` separately

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
