### PR TITLE
feat: add state hook closure fns

### DIFF
--- a/crates/evm/src/block/system_calls/mod.rs
+++ b/crates/evm/src/block/system_calls/mod.rs
@@ -4,7 +4,7 @@ use crate::{
     block::{BlockExecutionError, OnStateHook},
     Evm,
 };
-use alloc::boxed::Box;
+use alloc::{borrow::Cow, boxed::Box};
 use alloy_consensus::BlockHeader;
 use alloy_eips::{
     eip7002::WITHDRAWAL_REQUEST_TYPE, eip7251::CONSOLIDATION_REQUEST_TYPE, eip7685::Requests,
@@ -183,11 +183,11 @@ where
     /// Invokes the state hook with the outcome of the given closure.
     pub fn on_state_with<'a, F>(&mut self, f: F)
     where
-        F: FnOnce() -> (StateChangeSource, &'a EvmState),
+        F: FnOnce() -> (StateChangeSource, Cow<'a, EvmState>),
     {
         self.invoke_hook_with(|hook| {
             let (source, state) = f();
-            hook.on_state(source, state);
+            hook.on_state(source, &state);
         });
     }
 

--- a/crates/evm/src/block/system_calls/mod.rs
+++ b/crates/evm/src/block/system_calls/mod.rs
@@ -179,4 +179,23 @@ where
             hook.on_state(source, state);
         }
     }
+
+    /// Invokes the state hook with the outcome of the given closure.
+    pub fn on_state_with<'a, F>(&mut self, f: F)
+    where
+        F: FnOnce() -> (StateChangeSource, &'a EvmState),
+    {
+        self.invoke_hook_with(|hook| {
+            let (source, state) = f();
+            hook.on_state(source, state);
+        });
+    }
+
+    /// Invokes the given closure with the configured state hook if any.
+    pub fn invoke_hook_with<F, R>(&mut self, f: F) -> Option<R>
+    where
+        F: FnOnce(&mut Box<dyn OnStateHook>) -> R,
+    {
+        self.hook.as_mut().map(f)
+    }
 }


### PR DESCRIPTION
adds helper fns that make it possible to invoke the state hook with a closure so that we're not required to always collect the evmstate and can do that in a closure instead

can be used after #26