### PR TITLE
feat: `BlockExecutorFactory`

### DIFF
--- a/crates/evm/src/block/mod.rs
+++ b/crates/evm/src/block/mod.rs
@@ -1,10 +1,12 @@
 //! Block execution abstraction.
 
-use crate::Evm;
+use crate::{Evm, EvmFactory, Database};
 use alloc::{boxed::Box, vec::Vec};
 use alloy_consensus::transaction::Recovered;
 use alloy_eips::eip7685::Requests;
-use revm::context::result::ExecutionResult;
+use revm::{
+    context::result::ExecutionResult, database::State, inspector::NoOpInspector, Inspector
+};
 
 mod error;
 pub use error::*;
@@ -30,7 +32,7 @@ pub struct BlockExecutionResult<T> {
     pub gas_used: u64,
 }
 
-/// A type that knows how to execute g a single block.
+/// A type that knows how to execute a single block.
 ///
 /// The current abstraction assumes that block execution consists of the following steps:
 /// 1. Apply pre-execution changes. Those might include system calls, irregular state transitions
@@ -101,4 +103,65 @@ pub trait BlockExecutor {
 
     /// Exposes mutable reference to EVM.
     fn evm_mut(&mut self) -> &mut Self::Evm;
+}
+
+/// A helper trait encapsulating the constraints on [`BlockExecutor`] produced by the
+/// [`BlockExecutorFactory`] to avoid duplicating them in every implementation.
+pub trait BlockExecutorFor<'a, F: BlockExecutorFactory + ?Sized, DB, I = NoOpInspector>
+where
+    Self: BlockExecutor<
+        Evm = F::Evm<&'a mut State<DB>, I>,
+        Transaction = F::Transaction,
+        Receipt = F::Receipt,
+    >,
+    DB: Database + 'a,
+    I: Inspector<F::Context<&'a mut State<DB>>> + 'a,
+{
+}
+
+impl<'a, F, DB, I, T> BlockExecutorFor<'a, F, DB, I> for T
+where
+    F: BlockExecutorFactory,
+    DB: Database + 'a,
+    I: Inspector<F::Context<&'a mut State<DB>>> + 'a,
+    T: BlockExecutor<
+        Evm = F::Evm<&'a mut State<DB>, I>,
+        Transaction = F::Transaction,
+        Receipt = F::Receipt,
+    >,
+{
+}
+
+/// A factory that can create [`BlockExecutor`]s.
+///
+/// This trait extends [`crate::EvmFactory`] and provides a way to construct a [`BlockExecutor`].
+/// Executor is expected to derive most of the context for block execution from the EVM (which
+/// includes [`revm::context::BlockEnv`]), and any additional context should be contained in
+/// configured [`ExecutionCtx`].
+///
+/// For more context on the executor design, see the documentation for [`BlockExecutor`].
+///
+/// [`ExecutionCtx`]: BlockExecutorFactory::ExecutionCtx
+pub trait BlockExecutorFactory: EvmFactory + 'static {
+    /// Context required for block execution.
+    ///
+    /// This is similar to [`crate::EvmEnv`], but only contains context unrelated to EVM and
+    /// required for execution of an entire block.
+    type ExecutionCtx<'a>: Clone;
+
+    /// Transaction type used by the executor, see [`BlockExecutor::Transaction`].
+    type Transaction;
+
+    /// Receipt type produced by the executor, see [`BlockExecutor::Receipt`].
+    type Receipt;
+
+    /// Creates an executor with given EVM and execution context.
+    fn create_executor<'a, DB, I>(
+        &'a self,
+        evm: Self::Evm<&'a mut State<DB>, I>,
+        ctx: Self::ExecutionCtx<'a>,
+    ) -> impl BlockExecutorFor<'a, Self, DB, I>
+    where
+        DB: Database + 'a,
+        I: Inspector<Self::Context<&'a mut State<DB>>> + 'a;
 }

--- a/crates/evm/src/eth/mod.rs
+++ b/crates/evm/src/eth/mod.rs
@@ -7,6 +7,7 @@ use core::{
     fmt::Debug,
     ops::{Deref, DerefMut},
 };
+use receipt_builder::AlloyReceiptBuilder;
 use revm::{
     context::{setters::ContextSetters, BlockEnv, CfgEnv, Evm as RevmEvm, TxEnv},
     context_interface::result::{EVMError, HaltReason, ResultAndState},
@@ -16,6 +17,7 @@ use revm::{
     specification::hardfork::SpecId,
     Context, ExecuteEvm, InspectEvm, Inspector, MainBuilder, MainContext,
 };
+use spec::EthSpec;
 
 mod block;
 pub use block::*;
@@ -181,9 +183,14 @@ where
 /// Factory producing [`EthEvm`].
 #[derive(Debug, Default, Clone, Copy)]
 #[non_exhaustive]
-pub struct EthEvmFactory;
+pub struct EthEvmFactory<R = AlloyReceiptBuilder, Spec = EthSpec> {
+    /// Receipt builder.
+    receipt_builder: R,
+    /// Chain specification.
+    spec: Spec,
+}
 
-impl EvmFactory for EthEvmFactory {
+impl<R, Spec> EvmFactory for EthEvmFactory<R, Spec> {
     type Evm<DB: Database, I: Inspector<EthEvmContext<DB>>> = EthEvm<DB, I>;
     type Context<DB: Database> = Context<BlockEnv, TxEnv, CfgEnv, DB>;
     type Tx = TxEnv;

--- a/crates/evm/src/eth/receipt_builder.rs
+++ b/crates/evm/src/eth/receipt_builder.rs
@@ -23,14 +23,17 @@ pub struct ReceiptBuilderCtx<'a, T, E: Evm> {
 
 /// Type that knows how to build a receipt based on execution result.
 #[auto_impl::auto_impl(&, Arc)]
-pub trait ReceiptBuilder<E: Evm> {
+pub trait ReceiptBuilder {
     /// Transaction type.
     type Transaction;
     /// Receipt type.
     type Receipt;
 
     /// Builds a receipt given a transaction and the result of the execution.
-    fn build_receipt(&self, ctx: ReceiptBuilderCtx<'_, Self::Transaction, E>) -> Self::Receipt;
+    fn build_receipt<E: Evm>(
+        &self,
+        ctx: ReceiptBuilderCtx<'_, Self::Transaction, E>,
+    ) -> Self::Receipt;
 }
 
 /// Receipt builder operating on Alloy types.
@@ -38,11 +41,11 @@ pub trait ReceiptBuilder<E: Evm> {
 #[non_exhaustive]
 pub struct AlloyReceiptBuilder;
 
-impl<E: Evm> ReceiptBuilder<E> for AlloyReceiptBuilder {
+impl ReceiptBuilder for AlloyReceiptBuilder {
     type Transaction = TxEnvelope;
     type Receipt = ReceiptEnvelope;
 
-    fn build_receipt(&self, ctx: ReceiptBuilderCtx<'_, TxEnvelope, E>) -> Self::Receipt {
+    fn build_receipt<E: Evm>(&self, ctx: ReceiptBuilderCtx<'_, TxEnvelope, E>) -> Self::Receipt {
         let receipt = alloy_consensus::Receipt {
             status: Eip658Value::Eip658(ctx.result.is_success()),
             cumulative_gas_used: ctx.cumulative_gas_used,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Moves `BlockExecutionStrategyFactory` from reth with changed name and a bit different semantics.

I've decided to remove GAT for `Strategy`/`Executor` in favor of using RPIT with a helper trait. It solves the redundancy of writing long `impl BlockExecutor<Evm = Self::Evm<'a, DB, I>, Transaction = Self::Tranaction, ...>` and allows to make `BlockExecutorFactory` impls smaller as GAT definition is pretty big.

We could do the same for Evm as this GAT is not ideal as well, https://github.com/alloy-rs/evm/blob/0340109184517986eb8bd7f5ac20d67513f80920/crates/evm/src/evm.rs#L116-L122

It is also impractical to bound because non-lifetime binders (`Evm: for<DB, I>: MyTrait`) are not supported. However, it is still useful in scope of block executors which might depend on a concrete type of `Evm` produced by `EvmFactory` for e.g using some custom helpers defined on it 

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
