### PR TITLE
fix(ci): enable std for tests

### DIFF
--- a/.config/zepter.yaml
+++ b/.config/zepter.yaml
@@ -18,7 +18,6 @@ workflows:
         # Ignore the case that `A` it outside of the workspace. Otherwise it will report errors in external dependencies that we have no influence on.
         "--left-side-outside-workspace=ignore",
         # limit to the workspace
-        "--workspace",
         "--show-path",
         "--quiet",
       ]

--- a/crates/evm/Cargo.toml
+++ b/crates/evm/Cargo.toml
@@ -28,6 +28,7 @@ derive_more.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
+alloy-evm = { workspace = true, features = ["std"] }
 alloy-primitives = { workspace = true, features = ["serde"] }
 serde_json.workspace = true
 
@@ -35,6 +36,13 @@ serde_json.workspace = true
 default = ["std"]
 std = [
 	"alloy-primitives/std",
-	"revm/std"
+	"revm/std",
+	"alloy-consensus/std",
+	"alloy-eips/std",
+	"alloy-evm/std",
+	"alloy-sol-types/std",
+	"derive_more/std",
+	"op-revm?/std",
+	"thiserror/std"
 ]
 op = ["op-revm"]

--- a/crates/op-evm/Cargo.toml
+++ b/crates/op-evm/Cargo.toml
@@ -25,5 +25,6 @@ default = ["std"]
 std = [
 	"alloy-primitives/std",
 	"revm/std",
-	"alloy-evm/std"
+	"alloy-evm/std",
+	"op-revm/std"
 ]

--- a/scripts/check_no_std.sh
+++ b/scripts/check_no_std.sh
@@ -2,6 +2,8 @@
 set -eo pipefail
 
 no_std_packages=(
+  alloy-evm
+  alloy-op-evm
 )
 
 for package in "${no_std_packages[@]}"; do


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

`critical-section` causes some issues during linking on windows, so we need to enable `std` when running tests. We're still testing no-std 

Also applied changes to zepter config as in https://github.com/alloy-rs/alloy/pull/2144 and fixed no-std checks script

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
