### PR TITLE
fix: correctly handle state after system calls

### DIFF
--- a/crates/evm/src/block/system_calls/eip2935.rs
+++ b/crates/evm/src/block/system_calls/eip2935.rs
@@ -38,7 +38,7 @@ pub(crate) fn transact_blockhashes_contract_call<Halt>(
         return Ok(None);
     }
 
-    let mut res = match evm.transact_system_call(
+    let res = match evm.transact_system_call(
         alloy_eips::eip4788::SYSTEM_ADDRESS,
         HISTORY_STORAGE_ADDRESS,
         parent_block_hash.0.into(),
@@ -50,14 +50,6 @@ pub(crate) fn transact_blockhashes_contract_call<Halt>(
             )
         }
     };
-
-    // NOTE: Revm currently marks these accounts as "touched" when we do the above transact calls,
-    // and includes them in the result.
-    //
-    // There should be no state changes to these addresses anyways as a result of this system call,
-    // so we can just remove them from the state returned.
-    res.state.remove(&alloy_eips::eip4788::SYSTEM_ADDRESS);
-    res.state.remove(&evm.block().beneficiary);
 
     Ok(Some(res))
 }

--- a/crates/evm/src/block/system_calls/eip4788.rs
+++ b/crates/evm/src/block/system_calls/eip4788.rs
@@ -44,7 +44,7 @@ pub(crate) fn transact_beacon_root_contract_call<Halt>(
         return Ok(None);
     }
 
-    let mut res = match evm.transact_system_call(
+    let res = match evm.transact_system_call(
         alloy_eips::eip4788::SYSTEM_ADDRESS,
         BEACON_ROOTS_ADDRESS,
         parent_beacon_block_root.0.into(),
@@ -58,14 +58,6 @@ pub(crate) fn transact_beacon_root_contract_call<Halt>(
             .into())
         }
     };
-
-    // NOTE: Revm currently marks these accounts as "touched" when we do the above transact calls,
-    // and includes them in the result.
-    //
-    // There should be no state changes to these addresses anyways as a result of this system call,
-    // so we can just remove them from the state returned.
-    res.state.remove(&alloy_eips::eip4788::SYSTEM_ADDRESS);
-    res.state.remove(&evm.block().beneficiary);
 
     Ok(Some(res))
 }

--- a/crates/evm/src/block/system_calls/eip7002.rs
+++ b/crates/evm/src/block/system_calls/eip7002.rs
@@ -27,7 +27,7 @@ pub(crate) fn transact_withdrawal_requests_contract_call<Halt>(
     // At the end of processing any execution block where `block.timestamp >= FORK_TIMESTAMP` (i.e.
     // after processing all transactions and after performing the block body withdrawal requests
     // validations), call the contract as `SYSTEM_ADDRESS`.
-    let mut res = match evm.transact_system_call(
+    let res = match evm.transact_system_call(
         alloy_eips::eip7002::SYSTEM_ADDRESS,
         WITHDRAWAL_REQUEST_PREDEPLOY_ADDRESS,
         Bytes::new(),
@@ -40,14 +40,6 @@ pub(crate) fn transact_withdrawal_requests_contract_call<Halt>(
             .into())
         }
     };
-
-    // NOTE: Revm currently marks these accounts as "touched" when we do the above transact calls,
-    // and includes them in the result.
-    //
-    // There should be no state changes to these addresses anyways as a result of this system call,
-    // so we can just remove them from the state returned.
-    res.state.remove(&alloy_eips::eip7002::SYSTEM_ADDRESS);
-    res.state.remove(&evm.block().beneficiary);
 
     Ok(res)
 }

--- a/crates/evm/src/block/system_calls/eip7251.rs
+++ b/crates/evm/src/block/system_calls/eip7251.rs
@@ -29,7 +29,7 @@ pub(crate) fn transact_consolidation_requests_contract_call<Halt>(
     // after processing all transactions and after performing the block body requests validations)
     // clienst software MUST [..] call the contract as `SYSTEM_ADDRESS` and empty input data to
     // trigger the system subroutine execute.
-    let mut res = match evm.transact_system_call(
+    let res = match evm.transact_system_call(
         alloy_eips::eip7002::SYSTEM_ADDRESS,
         CONSOLIDATION_REQUEST_PREDEPLOY_ADDRESS,
         Bytes::new(),
@@ -42,14 +42,6 @@ pub(crate) fn transact_consolidation_requests_contract_call<Halt>(
             .into())
         }
     };
-
-    // NOTE: Revm currently marks these accounts as "touched" when we do the above transact calls,
-    // and includes them in the result.
-    //
-    // There should be no state changes to these addresses anyways as a result of this system call,
-    // so we can just remove them from the state returned.
-    res.state.remove(&alloy_eips::eip7002::SYSTEM_ADDRESS);
-    res.state.remove(&evm.block().beneficiary);
 
     Ok(res)
 }

--- a/crates/evm/src/eth/mod.rs
+++ b/crates/evm/src/eth/mod.rs
@@ -167,7 +167,7 @@ where
         // disable the nonce check
         core::mem::swap(&mut self.cfg.disable_nonce_check, &mut disable_nonce_check);
 
-        let res = self.transact(tx);
+        let mut res = self.transact(tx);
 
         // swap back to the previous gas limit
         core::mem::swap(&mut self.block.gas_limit, &mut gas_limit);
@@ -175,6 +175,11 @@ where
         core::mem::swap(&mut self.block.basefee, &mut basefee);
         // swap back to the previous nonce check flag
         core::mem::swap(&mut self.cfg.disable_nonce_check, &mut disable_nonce_check);
+
+        // NOTE: Revm might commit the nonce state change for the caller but we want to avoid it.
+        if let Ok(res) = &mut res {
+            res.state.remove(&caller);
+        }
 
         res
     }

--- a/crates/evm/src/eth/mod.rs
+++ b/crates/evm/src/eth/mod.rs
@@ -176,7 +176,12 @@ where
         // swap back to the previous nonce check flag
         core::mem::swap(&mut self.cfg.disable_nonce_check, &mut disable_nonce_check);
 
-        // NOTE: We assume that only the contract storage is modified.
+        // NOTE: We assume that only the contract storage is modified. Revm currently marks the
+        // caller and block beneficiary accounts as "touched" when we do the above transact calls,
+        // and includes them in the result.
+        //
+        // We're doing this state cleanup to make sure that changeset only includes the changed
+        // contract storage.
         if let Ok(res) = &mut res {
             res.state.retain(|addr, _| *addr == contract);
         }

--- a/crates/evm/src/eth/mod.rs
+++ b/crates/evm/src/eth/mod.rs
@@ -176,9 +176,9 @@ where
         // swap back to the previous nonce check flag
         core::mem::swap(&mut self.cfg.disable_nonce_check, &mut disable_nonce_check);
 
-        // NOTE: Revm might commit the nonce state change for the caller but we want to avoid it.
+        // NOTE: We assume that only the contract storage is modified.
         if let Ok(res) = &mut res {
-            res.state.remove(&caller);
+            res.state.retain(|addr, _| *addr == contract);
         }
 
         res

--- a/crates/evm/src/evm.rs
+++ b/crates/evm/src/evm.rs
@@ -62,6 +62,10 @@ pub trait Evm {
     }
 
     /// Executes a system call.
+    ///
+    /// Note: this will only keep the target `contract` in the state. This is done because revm is
+    /// loading [`BlockEnv::beneficiary`] into state by default, and we need to avoid it by also
+    /// covering edge cases when beneficiary is set to the system contract address.
     fn transact_system_call(
         &mut self,
         caller: Address,

--- a/crates/op-evm/src/lib.rs
+++ b/crates/op-evm/src/lib.rs
@@ -165,7 +165,7 @@ where
         // disable the nonce check
         core::mem::swap(&mut self.cfg.disable_nonce_check, &mut disable_nonce_check);
 
-        let res = self.transact(tx);
+        let mut res = self.transact(tx);
 
         // swap back to the previous gas limit
         core::mem::swap(&mut self.block.gas_limit, &mut gas_limit);
@@ -173,6 +173,11 @@ where
         core::mem::swap(&mut self.block.basefee, &mut basefee);
         // swap back to the previous nonce check flag
         core::mem::swap(&mut self.cfg.disable_nonce_check, &mut disable_nonce_check);
+
+        // NOTE: Revm might commit the nonce state change for the caller but we want to avoid it.
+        if let Ok(res) = &mut res {
+            res.state.remove(&caller);
+        }
 
         res
     }

--- a/crates/op-evm/src/lib.rs
+++ b/crates/op-evm/src/lib.rs
@@ -174,9 +174,9 @@ where
         // swap back to the previous nonce check flag
         core::mem::swap(&mut self.cfg.disable_nonce_check, &mut disable_nonce_check);
 
-        // NOTE: Revm might commit the nonce state change for the caller but we want to avoid it.
+        // NOTE: We assume that only the contract storage is modified.
         if let Ok(res) = &mut res {
-            res.state.remove(&caller);
+            res.state.retain(|addr, _| *addr == contract);
         }
 
         res

--- a/crates/op-evm/src/lib.rs
+++ b/crates/op-evm/src/lib.rs
@@ -174,7 +174,12 @@ where
         // swap back to the previous nonce check flag
         core::mem::swap(&mut self.cfg.disable_nonce_check, &mut disable_nonce_check);
 
-        // NOTE: We assume that only the contract storage is modified.
+        // NOTE: We assume that only the contract storage is modified. Revm currently marks the
+        // caller and block beneficiary accounts as "touched" when we do the above transact calls,
+        // and includes them in the result.
+        //
+        // We're doing this state cleanup to make sure that changeset only includes the changed
+        // contract storage.
         if let Ok(res) = &mut res {
             res.state.retain(|addr, _| *addr == contract);
         }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

There's an edge case when system contract is set to block beneficiary, so we can't simply remove it from the state. The assumption here is that there will not be any state changes to beneficiary due to fee accounting, and we can safely keep it in the state.


## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
