### PR TITLE
fix(isthmus): Assign deposit tx type to system call txs

### DIFF
--- a/crates/op-evm/src/lib.rs
+++ b/crates/op-evm/src/lib.rs
@@ -16,6 +16,7 @@ use core::{
     fmt::Debug,
     ops::{Deref, DerefMut},
 };
+use op_alloy_consensus::OpTxType;
 use op_revm::{
     precompiles::OpPrecompiles, DefaultOp, OpBuilder, OpContext, OpHaltReason, OpSpecId,
     OpTransaction, OpTransactionError,
@@ -145,7 +146,7 @@ where
                 // blob fields can be None for this tx
                 blob_hashes: Vec::new(),
                 max_fee_per_blob_gas: 0,
-                tx_type: 0,
+                tx_type: OpTxType::Deposit as u8,
                 authorization_list: Default::default(),
             },
             // The L1 fee is not charged for the EIP-4788 transaction, submit zero bytes for the


### PR DESCRIPTION
## Overview

Assigns the deposit tx type to system call transactions, so that `op-revm` skips transaction fee validation for them. The operator fee now can charge a non-zero fee even if the base fee is zero, and this bypasses the check and the attempted charge for pre-block syscalls.

http://github.com/bluealloy/revm/blob/080c29a2aef640063c7bcb30834ef7e998b8efe2/crates/optimism/src/handler.rs#L89-L90