### PR TITLE
feat(op-receipt-builder): Add Debug trait to OpReceiptBuilder.

### DIFF
--- a/crates/op-evm/src/block/receipt_builder.rs
+++ b/crates/op-evm/src/block/receipt_builder.rs
@@ -1,13 +1,14 @@
 //! Abstraction over receipt building logic to allow plugging different primitive types into
 //! [`super::OpBlockExecutor`].
 
+use core::fmt::Debug;
 use alloy_consensus::Eip658Value;
 use alloy_evm::{eth::receipt_builder::ReceiptBuilderCtx, Evm};
 use op_alloy_consensus::{OpDepositReceipt, OpReceiptEnvelope, OpTxEnvelope, OpTxType};
 
 /// Type that knows how to build a receipt based on execution result.
 #[auto_impl::auto_impl(&, Arc)]
-pub trait OpReceiptBuilder {
+pub trait OpReceiptBuilder: Debug {
     /// Transaction type.
     type Transaction;
     /// Receipt type.


### PR DESCRIPTION
This will help us abstract away manual addition of Debug constraint in `reth::OpEvmConfig`. 

Reference: https://github.com/paradigmxyz/reth/pull/15307/files#r2014643863
