### PR TITLE
rm create_evm_with_inspector fn

### DIFF
--- a/crates/evm/src/eth/mod.rs
+++ b/crates/evm/src/eth/mod.rs
@@ -11,7 +11,6 @@ use revm::{
     context::{BlockEnv, CfgEnv, Evm as RevmEvm, TxEnv},
     context_interface::result::{EVMError, HaltReason, ResultAndState},
     handler::{instructions::EthInstructions, EthPrecompiles, PrecompileProvider},
-    inspector::NoOpInspector,
     interpreter::{interpreter::EthInterpreter, InterpreterResult},
     primitives::hardfork::SpecId,
     Context, ExecuteEvm, InspectEvm, Inspector, MainBuilder, MainContext,
@@ -217,18 +216,7 @@ impl EvmFactory for EthEvmFactory {
     type HaltReason = HaltReason;
     type Spec = SpecId;
 
-    fn create_evm<DB: Database>(&self, db: DB, input: EvmEnv) -> Self::Evm<DB, NoOpInspector> {
-        EthEvm {
-            inner: Context::mainnet()
-                .with_block(input.block_env)
-                .with_cfg(input.cfg_env)
-                .with_db(db)
-                .build_mainnet_with_inspector(NoOpInspector {}),
-            inspect: false,
-        }
-    }
-
-    fn create_evm_with_inspector<DB: Database, I: Inspector<Self::Context<DB>>>(
+    fn create_evm<DB: Database, I: Inspector<Self::Context<DB>>>(
         &self,
         db: DB,
         input: EvmEnv,
@@ -240,7 +228,7 @@ impl EvmFactory for EthEvmFactory {
                 .with_cfg(input.cfg_env)
                 .with_db(db)
                 .build_mainnet_with_inspector(inspector),
-            inspect: true,
+            inspect: false,
         }
     }
 }

--- a/crates/evm/src/evm.rs
+++ b/crates/evm/src/evm.rs
@@ -9,7 +9,7 @@ use revm::{
         result::{HaltReasonTr, ResultAndState},
         ContextTr,
     },
-    inspector::{JournalExt, NoOpInspector},
+    inspector::JournalExt,
     DatabaseCommit, Inspector,
 };
 
@@ -154,20 +154,13 @@ pub trait EvmFactory {
     type Spec: Debug + Copy + Send + Sync + 'static;
 
     /// Creates a new instance of an EVM.
-    fn create_evm<DB: Database>(
-        &self,
-        db: DB,
-        evm_env: EvmEnv<Self::Spec>,
-    ) -> Self::Evm<DB, NoOpInspector>;
-
-    /// Creates a new instance of an EVM with an inspector.
     ///
     /// Note: It is expected that the [`Inspector`] is usually provided as `&mut Inspector` so that
     /// it remains owned by the call site when [`Evm::transact`] is invoked.
-    fn create_evm_with_inspector<DB: Database, I: Inspector<Self::Context<DB>>>(
+    fn create_evm<DB: Database, I: Inspector<Self::Context<DB>>>(
         &self,
         db: DB,
-        input: EvmEnv<Self::Spec>,
+        evm_env: EvmEnv<Self::Spec>,
         inspector: I,
     ) -> Self::Evm<DB, I>;
 }

--- a/crates/op-evm/src/block/mod.rs
+++ b/crates/op-evm/src/block/mod.rs
@@ -314,7 +314,7 @@ mod tests {
     use alloy_evm::EvmEnv;
     use alloy_primitives::{Address, PrimitiveSignature as Signature};
     use op_alloy_consensus::OpTxEnvelope;
-    use revm::database::{CacheDB, EmptyDB};
+    use revm::{database::{CacheDB, EmptyDB}, inspector::NoOpInspector};
 
     use super::*;
 
@@ -326,7 +326,7 @@ mod tests {
             OpEvmFactory::default(),
         );
         let mut db = State::builder().with_database(CacheDB::<EmptyDB>::default()).build();
-        let evm = executor_factory.evm_factory.create_evm(&mut db, EvmEnv::default());
+        let evm = executor_factory.evm_factory.create_evm(&mut db, EvmEnv::default(), NoOpInspector{});
         let mut executor = executor_factory.create_executor(evm, OpBlockExecutionCtx::default());
         let tx = Recovered::new_unchecked(
             OpTxEnvelope::Legacy(TxLegacy::default().into_signed(Signature::new(

--- a/crates/op-evm/src/lib.rs
+++ b/crates/op-evm/src/lib.rs
@@ -25,7 +25,6 @@ use revm::{
     context::{BlockEnv, TxEnv},
     context_interface::result::{EVMError, ResultAndState},
     handler::{instructions::EthInstructions, PrecompileProvider},
-    inspector::NoOpInspector,
     interpreter::{interpreter::EthInterpreter, InterpreterResult},
     Context, ExecuteEvm, InspectEvm, Inspector,
 };
@@ -217,22 +216,7 @@ impl EvmFactory for OpEvmFactory {
     type HaltReason = OpHaltReason;
     type Spec = OpSpecId;
 
-    fn create_evm<DB: Database>(
-        &self,
-        db: DB,
-        input: EvmEnv<OpSpecId>,
-    ) -> Self::Evm<DB, NoOpInspector> {
-        OpEvm {
-            inner: Context::op()
-                .with_db(db)
-                .with_block(input.block_env)
-                .with_cfg(input.cfg_env)
-                .build_op_with_inspector(NoOpInspector {}),
-            inspect: false,
-        }
-    }
-
-    fn create_evm_with_inspector<DB: Database, I: Inspector<Self::Context<DB>>>(
+    fn create_evm<DB: Database, I: Inspector<Self::Context<DB>>>(
         &self,
         db: DB,
         input: EvmEnv<OpSpecId>,
@@ -244,7 +228,7 @@ impl EvmFactory for OpEvmFactory {
                 .with_block(input.block_env)
                 .with_cfg(input.cfg_env)
                 .build_op_with_inspector(inspector),
-            inspect: true,
+            inspect: false,
         }
     }
 }


### PR DESCRIPTION
Change regarding issue #52 

Seems redundant to have inspector flag passed to `EthEvm::new()` and also have another function which creates the same evm with an inspector. In the current design the create_evm() inspector can not be enabled via the enable_inspector toggle since it is a `NoOpInspector`.

## Motivation

Say I want to call `self.evm.enable_inspector()` in `BlockExecutor:: execute_transaction_with_result_closure()` and then transact the tx... In current design the inspector is `NoOpInspector` so a custom inspector could not be used in `execute_transaction_with_result_closure()`.