### PR TITLE
feat(tx): Add `FromTxWithEncoded` bound to `BlockExecutor` transaction

### DIFF
--- a/crates/evm/src/block/mod.rs
+++ b/crates/evm/src/block/mod.rs
@@ -1,6 +1,8 @@
 //! Block execution abstraction.
 
-use crate::{Database, Evm, EvmFactory, FromRecoveredTx, IntoTxEnv, RecoveredTx};
+use crate::{
+    Database, Evm, EvmFactory, FromRecoveredTx, FromTxWithEncoded, IntoTxEnv, RecoveredTx,
+};
 use alloc::{boxed::Box, vec::Vec};
 use alloy_eips::eip7685::Requests;
 use revm::{
@@ -58,7 +60,7 @@ pub trait BlockExecutor {
     /// Receipt type this executor produces.
     type Receipt;
     /// EVM used by the executor.
-    type Evm: Evm<Tx: FromRecoveredTx<Self::Transaction>>;
+    type Evm: Evm<Tx: FromRecoveredTx<Self::Transaction> + FromTxWithEncoded<Self::Transaction>>;
 
     /// Applies any necessary changes before executing the block's transactions.
     fn apply_pre_execution_changes(&mut self) -> Result<(), BlockExecutionError>;

--- a/crates/evm/src/eth/block.rs
+++ b/crates/evm/src/eth/block.rs
@@ -13,7 +13,7 @@ use crate::{
         BlockExecutorFor, BlockValidationError, ExecutableTx, OnStateHook,
         StateChangePostBlockSource, StateChangeSource, SystemCaller,
     },
-    Database, Evm, EvmFactory, FromRecoveredTx,
+    Database, Evm, EvmFactory, FromRecoveredTx, FromTxWithEncoded,
 };
 use alloc::{borrow::Cow, boxed::Box, vec::Vec};
 use alloy_consensus::{Header, Transaction, TxReceipt};
@@ -81,7 +81,10 @@ where
 impl<'db, DB, E, Spec, R> BlockExecutor for EthBlockExecutor<'_, E, Spec, R>
 where
     DB: Database + 'db,
-    E: Evm<DB = &'db mut State<DB>, Tx: FromRecoveredTx<R::Transaction>>,
+    E: Evm<
+        DB = &'db mut State<DB>,
+        Tx: FromRecoveredTx<R::Transaction> + FromTxWithEncoded<R::Transaction>,
+    >,
     Spec: EthExecutorSpec,
     R: ReceiptBuilder<Transaction: Transaction + Encodable2718, Receipt: TxReceipt<Log = Log>>,
 {
@@ -269,7 +272,7 @@ impl<R, Spec, EvmF> BlockExecutorFactory for EthBlockExecutorFactory<R, Spec, Ev
 where
     R: ReceiptBuilder<Transaction: Transaction + Encodable2718, Receipt: TxReceipt<Log = Log>>,
     Spec: EthExecutorSpec,
-    EvmF: EvmFactory<Tx: FromRecoveredTx<R::Transaction>>,
+    EvmF: EvmFactory<Tx: FromRecoveredTx<R::Transaction> + FromTxWithEncoded<R::Transaction>>,
     Self: 'static,
 {
     type EvmFactory = EvmF;

--- a/crates/op-evm/src/block/mod.rs
+++ b/crates/op-evm/src/block/mod.rs
@@ -12,7 +12,7 @@ use alloy_evm::{
         StateChangePostBlockSource, StateChangeSource, SystemCaller,
     },
     eth::receipt_builder::ReceiptBuilderCtx,
-    Database, Evm, EvmFactory, FromRecoveredTx,
+    Database, Evm, EvmFactory, FromRecoveredTx, FromTxWithEncoded,
 };
 use alloy_op_hardforks::{OpChainHardforks, OpHardforks};
 use alloy_primitives::{Bytes, B256};
@@ -83,7 +83,10 @@ where
 impl<'db, DB, E, R, Spec> BlockExecutor for OpBlockExecutor<E, R, Spec>
 where
     DB: Database + 'db,
-    E: Evm<DB = &'db mut State<DB>, Tx: FromRecoveredTx<R::Transaction>>,
+    E: Evm<
+        DB = &'db mut State<DB>,
+        Tx: FromRecoveredTx<R::Transaction> + FromTxWithEncoded<R::Transaction>,
+    >,
     R: OpReceiptBuilder<Transaction: Transaction + Encodable2718, Receipt: TxReceipt>,
     Spec: OpHardforks,
 {
@@ -282,7 +285,7 @@ impl<R, Spec, EvmF> BlockExecutorFactory for OpBlockExecutorFactory<R, Spec, Evm
 where
     R: OpReceiptBuilder<Transaction: Transaction + Encodable2718, Receipt: TxReceipt>,
     Spec: OpHardforks,
-    EvmF: EvmFactory<Tx: FromRecoveredTx<R::Transaction>>,
+    EvmF: EvmFactory<Tx: FromRecoveredTx<R::Transaction> + FromTxWithEncoded<R::Transaction>>,
     Self: 'static,
 {
     type EvmFactory = EvmF;


### PR DESCRIPTION
## Motivation

Currently, the opstack use-case of `eth_simulate` on reth charges user L1 data cost due to the way tx envelope is derived for serialized transaction.

This is divergent from op-geth logic, where the L1 data cost is not charged.

The simulation fails for users with lower balance, where it should not fail.

## Solution

Allows for empty envelopes as part of https://github.com/paradigmxyz/reth/issues/15292

Empty envelopes will contain zero L1 data cost.

A `FromTxWithEncoded` trait bound is added to associated transaction type on `BlockExecutor`. This allows to create the tx envelope using `WithEncoded::new(Default::default(), tx)`

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
