### PR TITLE
feat(evm): Add `PrecompileProvider` associated type to `EvmFactory`

### DIFF
--- a/crates/evm/src/eth/mod.rs
+++ b/crates/evm/src/eth/mod.rs
@@ -214,12 +214,13 @@ where
 pub struct EthEvmFactory;
 
 impl EvmFactory for EthEvmFactory {
-    type Evm<DB: Database, I: Inspector<EthEvmContext<DB>>> = EthEvm<DB, I>;
+    type Evm<DB: Database, I: Inspector<EthEvmContext<DB>>> = EthEvm<DB, I, Self::Precompiles<DB>>;
     type Context<DB: Database> = Context<BlockEnv, TxEnv, CfgEnv, DB>;
     type Tx = TxEnv;
     type Error<DBError: core::error::Error + Send + Sync + 'static> = EVMError<DBError>;
     type HaltReason = HaltReason;
     type Spec = SpecId;
+    type Precompiles<DB: Database> = EthPrecompiles;
 
     fn create_evm<DB: Database>(&self, db: DB, input: EvmEnv) -> Self::Evm<DB, NoOpInspector> {
         EthEvm {

--- a/crates/evm/src/evm.rs
+++ b/crates/evm/src/evm.rs
@@ -9,7 +9,9 @@ use revm::{
         result::{HaltReasonTr, ResultAndState},
         ContextTr,
     },
+    handler::PrecompileProvider,
     inspector::{JournalExt, NoOpInspector},
+    interpreter::InterpreterResult,
     DatabaseCommit, Inspector,
 };
 
@@ -155,6 +157,9 @@ pub trait EvmFactory {
     type HaltReason: HaltReasonTr + Send + Sync + 'static;
     /// The EVM specification identifier, see [`Evm::Spec`].
     type Spec: Debug + Copy + Send + Sync + 'static;
+    /// The [`PrecompileProvider`] type for the EVM.
+    type Precompiles<DB: Database>: PrecompileProvider<Self::Context<DB>, Output = InterpreterResult>
+        + Clone;
 
     /// Creates a new instance of an EVM.
     fn create_evm<DB: Database>(

--- a/crates/op-evm/src/lib.rs
+++ b/crates/op-evm/src/lib.rs
@@ -213,13 +213,14 @@ where
 pub struct OpEvmFactory;
 
 impl EvmFactory for OpEvmFactory {
-    type Evm<DB: Database, I: Inspector<OpContext<DB>>> = OpEvm<DB, I>;
+    type Evm<DB: Database, I: Inspector<OpContext<DB>>> = OpEvm<DB, I, Self::Precompiles<DB>>;
     type Context<DB: Database> = OpContext<DB>;
     type Tx = OpTransaction<TxEnv>;
     type Error<DBError: core::error::Error + Send + Sync + 'static> =
         EVMError<DBError, OpTransactionError>;
     type HaltReason = OpHaltReason;
     type Spec = OpSpecId;
+    type Precompiles<DB: Database> = OpPrecompiles;
 
     fn create_evm<DB: Database>(
         &self,


### PR DESCRIPTION
## Overview

Adds a new associated type to the `EvmFactory` for a [`PrecompileProvider`](https://docs.rs/revm-handler/latest/revm_handler/trait.PrecompileProvider.html) trait implementation.

On the default `EvmFactory` implementations that `alloy-evm` and `alloy-op-evm` serve, this associated type is set to `EthPrecompiles` and `OpPrecompiles` respectively (i.e., no functional change.)

For usecases such as in [`kona`](https://github.com/op-rs/kona), where a custom `EvmFactory` implementation is warranted to accommodate the OP stack proof's ["accelerated precompiles"](https://specs.optimism.io/fault-proof/index.html?highlight=accelerate#precompile-accelerators), this simplifies the process.

---

This could also be achieved without this change by extending the interface of a new `EvmFactory` implementation like so:

```rs
pub struct MyEvmFactory<DB: Database> {
    /// Precompile provider.
    precompiles: <Self as Ext>::CustomPrecompiles<DB>,
}

pub trait Ext: EvmFactory {
    type CustomPrecompiles<DB: Database>: PrecompileProvider<<Self as EvmFactory>::Context<DB>> + Clone;
}

impl<ODB: Database> Ext for MyEvmFactory<ODB> {
    type CustomPrecompiles<DB: Database> = MyCustomPrecompiles;
}

impl<ODB: Database> EvmFactory for MyEvmFactory<ODB> {
    type Evm<DB: Database, I: Inspector<EthEvmContext<DB>>> = EthEvm<DB, I, <Self as Ext>::CustomPrecompiles<DB>>;
    
    // ... in the `create_evm` / `create_evm_with_inspector` fns, the precompiles get registered ...
}
```

but it seems non-invasive enough to just include it in the trait upstream so that folks don't need to jump through this hoop. Curious what the intended route is to do this is, if that's already been thought out - not entirely clear.