### PR TITLE
chore: Bump `op-revm` to `3.0.1`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ op-alloy-consensus = { version = "0.13", default-features = false }
 
 # revm
 revm = { version = "22.0.0", default-features = false }
-op-revm = { version = "3.0.0", default-features = false }
+op-revm = { version = "3.0.1", default-features = false }
 
 # misc
 auto_impl = "1"


### PR DESCRIPTION
## Overview

Bumps `op-revm`, including a patch for Isthmus.