### PR TITLE
feat: add SpecPrecompiles

### DIFF
--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -20,3 +20,4 @@ pub mod error;
 pub use error::*;
 pub mod tx;
 pub use tx::*;
+pub mod precompiles;

--- a/crates/evm/src/precompiles.rs
+++ b/crates/evm/src/precompiles.rs
@@ -241,16 +241,6 @@ impl From<PrecompileFn> for DynPrecompile {
     }
 }
 
-impl DynPrecompile {
-    /// Wraps this precompile with a custom implementation.
-    pub fn wrap<P: Precompile + Send + Sync + 'static>(
-        self,
-        wrapper: impl FnOnce(Self) -> P,
-    ) -> Self {
-        Self(Arc::new(wrapper(self)))
-    }
-}
-
 /// A mutable representation of precompiles that allows for runtime modification.
 ///
 /// This structure stores dynamic precompiles that can be modified at runtime,

--- a/crates/evm/src/precompiles.rs
+++ b/crates/evm/src/precompiles.rs
@@ -1,7 +1,9 @@
 //! Helpers for dealing with Precompiles.
 
 use alloc::borrow::Cow;
+use alloy_primitives::Address;
 use revm::{handler::EthPrecompiles, precompile::Precompiles, primitives::hardfork::SpecId};
+use revm::precompile::PrecompileFn;
 
 /// A set of Precompiles according to a spec.
 #[derive(Debug, Clone)]
@@ -14,6 +16,7 @@ pub struct SpecPrecompiles<Spec> {
     spec: Spec,
 }
 
+
 impl<Spec> SpecPrecompiles<Spec> {
     /// Creates the [`SpecPrecompiles`] from a static reference.
     pub const fn from_static(precompiles: &'static Precompiles, spec: Spec) -> Self {
@@ -23,6 +26,27 @@ impl<Spec> SpecPrecompiles<Spec> {
     /// Creates a new set of precompiles for that spec.
     pub fn new(precompiles: Cow<'static, Precompiles>, spec: Spec) -> Self {
         Self { precompiles, spec }
+    }
+    
+    /// Returns the configured precompiles
+    pub fn precompiles(&self) -> &Precompiles {
+        &self.precompiles
+    }
+    
+    /// Returns mutable access to the precompiles.
+    pub fn precompiles_mut(&mut self) -> &mut Precompiles {
+        self.precompiles.to_mut()
+    }
+    
+    /// Returns the configured spec.
+    pub const fn spec(&self) -> &Spec {
+        &self.spec
+    }
+    
+    pub fn map_precompile<F>(&mut self, address: &Address, f: F) where F: Fn(PrecompileFn) -> PrecompileFn {
+        if let Some(precompile) = self.precompiles_mut().get(address) {
+            
+        }
     }
 }
 

--- a/crates/evm/src/precompiles.rs
+++ b/crates/evm/src/precompiles.rs
@@ -26,7 +26,7 @@ pub enum PrecompilesMap {
 }
 
 impl PrecompilesMap {
-    /// Creates the [`SpecPrecompiles`] from a static reference.
+    /// Creates the [`PrecompilesMap`] from a static reference.
     pub fn from_static(precompiles: &'static Precompiles) -> Self {
         Self::new(Cow::Borrowed(precompiles))
     }

--- a/crates/evm/src/precompiles.rs
+++ b/crates/evm/src/precompiles.rs
@@ -44,21 +44,6 @@ where
     }
 }
 
-impl<T, L, R> core::ops::Deref for Either<L, R>
-where
-    L: core::ops::Deref<Target = T>,
-    R: core::ops::Deref<Target = T>,
-{
-    type Target = T;
-
-    fn deref(&self) -> &Self::Target {
-        match self {
-            Self::Left(value) => value.deref(),
-            Self::Right(value) => value.deref(),
-        }
-    }
-}
-
 // Direct implementation of Precompile for Both<DynPrecompile> and Both<PrecompileFnWrapper>
 impl Precompile for Either<PrecompileFnWrapper<'_>, &DynPrecompile> {
     fn call(&self, data: &Bytes, gas: u64) -> PrecompileResult {

--- a/crates/evm/src/precompiles.rs
+++ b/crates/evm/src/precompiles.rs
@@ -1,6 +1,6 @@
 //! Helpers for dealing with Precompiles.
 
-use alloc::{borrow::Cow, sync::Arc};
+use alloc::{borrow::Cow, boxed::Box, string::String, sync::Arc};
 use alloy_primitives::{
     map::{HashMap, HashSet},
     Address, Bytes,

--- a/crates/evm/src/precompiles.rs
+++ b/crates/evm/src/precompiles.rs
@@ -71,10 +71,11 @@ impl PrecompilesMap {
         let dyn_precompiles = self.ensure_dynamic_precompiles();
 
         // apply the transformation to each precompile
-        let mut new_map = HashMap::new();
-        for (addr, precompile) in &dyn_precompiles.inner {
-            let transformed = f(addr, precompile.clone());
-            new_map.insert(*addr, transformed);
+        let entries = dyn_precompiles.inner.drain();
+        let mut new_map = HashMap::with_capacity(entries.size_hint().0);
+        for (addr, precompile) in entries {
+            let transformed = f(&addr, precompile);
+            new_map.insert(addr, transformed);
         }
 
         dyn_precompiles.inner = new_map;

--- a/crates/evm/src/precompiles.rs
+++ b/crates/evm/src/precompiles.rs
@@ -36,16 +36,6 @@ impl PrecompilesMap {
         Self::Builtin(precompiles)
     }
 
-    /// Returns the configured precompiles as a read-only reference.
-    pub fn precompiles(&self) -> &Self {
-        self
-    }
-
-    /// Returns mutable access to the precompiles as a DynPrecompiles.
-    pub fn precompiles_mut(&mut self) -> &mut Self {
-        self
-    }
-
     /// Maps a precompile at the given address using the provided function.
     pub fn map_precompile<F>(&mut self, address: &Address, f: F)
     where
@@ -329,8 +319,7 @@ mod tests {
         spec_precompiles.ensure_dynamic_precompiles();
 
         // using the dynamic precompiles interface
-        let precompiles = spec_precompiles.precompiles_mut();
-        let dyn_precompile = match precompiles {
+        let dyn_precompile = match &spec_precompiles {
             PrecompilesMap::Dynamic(dyn_precompiles) => {
                 dyn_precompiles.inner.get(&identity_address).unwrap()
             }
@@ -354,8 +343,7 @@ mod tests {
         });
 
         // get the modified precompile and check it
-        let precompiles = spec_precompiles.precompiles();
-        let dyn_precompile = match precompiles {
+        let dyn_precompile = match &spec_precompiles {
             PrecompilesMap::Dynamic(dyn_precompiles) => {
                 dyn_precompiles.inner.get(&identity_address).unwrap()
             }

--- a/crates/evm/src/precompiles.rs
+++ b/crates/evm/src/precompiles.rs
@@ -1,6 +1,6 @@
 //! Helpers for dealing with Precompiles.
 
-use alloc::{borrow::Cow, boxed::Box, string::String, sync::Arc, vec::Vec};
+use alloc::{borrow::Cow, boxed::Box, string::String, sync::Arc};
 use alloy_primitives::{
     map::{HashMap, HashSet},
     Address, Bytes,
@@ -133,11 +133,11 @@ impl PrecompilesMap {
         }
     }
 
-    /// Returns all precompile addresses.
-    fn addresses(&self) -> Vec<Address> {
+    /// Returns an iterator over references to precompile addresses.
+    fn addresses(&self) -> Box<dyn Iterator<Item = &Address> + '_> {
         match self {
-            Self::Builtin(precompiles) => precompiles.addresses().copied().collect(),
-            Self::Dynamic(dyn_precompiles) => dyn_precompiles.addresses.iter().copied().collect(),
+            Self::Builtin(precompiles) => Box::new(precompiles.addresses()),
+            Self::Dynamic(dyn_precompiles) => Box::new(dyn_precompiles.addresses.iter()),
         }
     }
 
@@ -248,9 +248,7 @@ impl<CTX: ContextTr> PrecompileProvider<CTX> for PrecompilesMap {
     }
 
     fn warm_addresses(&self) -> Box<impl Iterator<Item = Address>> {
-        // Get the addresses from the precompiles and convert to an iterator
-        let addresses = self.addresses();
-        Box::new(addresses.into_iter())
+        Box::new(self.addresses().copied())
     }
 
     fn contains(&self, address: &Address) -> bool {

--- a/crates/evm/src/precompiles.rs
+++ b/crates/evm/src/precompiles.rs
@@ -30,7 +30,7 @@ impl<Spec> SpecPrecompiles<Spec> {
 
     /// Creates a new set of precompiles for a spec.
     pub fn new(precompiles: Cow<'static, Precompiles>, spec: Spec) -> Self {
-        Self { precompiles: Self::as_dyn_precompiles(precompiles), spec }
+        Self { precompiles: as_dyn_precompiles(precompiles), spec }
     }
 
     /// Returns the configured precompiles as a read-only reference.
@@ -107,27 +107,27 @@ impl<Spec> SpecPrecompiles<Spec> {
             }
         }
     }
+}
 
-    /// Converts the given static precompiles into their dynamic representation.
-    fn as_dyn_precompiles(precompiles: Cow<'static, Precompiles>) -> DynPrecompiles {
-        // Convert static precompiles to dynamic immediately
-        let mut dynamic = DynPrecompiles::default();
+/// Converts the given static precompiles into their dynamic representation.
+fn as_dyn_precompiles(precompiles: Cow<'static, Precompiles>) -> DynPrecompiles {
+    // Convert static precompiles to dynamic immediately
+    let mut dynamic = DynPrecompiles::default();
 
-        // Get the static precompiles
-        let static_precompiles = match precompiles {
-            Cow::Borrowed(static_ref) => static_ref.clone(),
-            Cow::Owned(owned) => owned,
-        };
+    // Get the static precompiles
+    let static_precompiles = match precompiles {
+        Cow::Borrowed(static_ref) => static_ref.clone(),
+        Cow::Owned(owned) => owned,
+    };
 
-        // Convert all static precompiles to dynamic ones
-        for (addr, precompile_fn) in static_precompiles.inner() {
-            let dyn_precompile: DynPrecompile = (*precompile_fn).into();
-            dynamic.inner.insert(*addr, dyn_precompile);
-            dynamic.addresses.insert(*addr);
-        }
-
-        dynamic
+    // Convert all static precompiles to dynamic ones
+    for (addr, precompile_fn) in static_precompiles.inner() {
+        let dyn_precompile: DynPrecompile = (*precompile_fn).into();
+        dynamic.inner.insert(*addr, dyn_precompile);
+        dynamic.addresses.insert(*addr);
     }
+
+    dynamic
 }
 
 impl From<EthPrecompiles> for SpecPrecompiles<SpecId> {
@@ -148,7 +148,7 @@ where
             return false;
         }
 
-        self.precompiles = Self::as_dyn_precompiles(Cow::Borrowed(Precompiles::new(
+        self.precompiles = as_dyn_precompiles(Cow::Borrowed(Precompiles::new(
             PrecompileSpecId::from_spec_id(spec.clone().into()),
         )));
         self.spec = spec;

--- a/crates/evm/src/precompiles.rs
+++ b/crates/evm/src/precompiles.rs
@@ -180,16 +180,6 @@ impl From<EthPrecompiles> for PrecompilesMap {
 //    }
 //}
 
-impl PartialEq for PrecompilesMap {
-    fn eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            (Self::Builtin(_), Self::Builtin(_)) => true,
-            (Self::Dynamic(a), Self::Dynamic(b)) => a.addresses == b.addresses,
-            _ => false,
-        }
-    }
-}
-
 impl core::fmt::Debug for PrecompilesMap {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {

--- a/crates/evm/src/precompiles.rs
+++ b/crates/evm/src/precompiles.rs
@@ -1,0 +1,33 @@
+//! Helpers for dealing with Precompiles.
+
+use alloc::borrow::Cow;
+use revm::{handler::EthPrecompiles, precompile::Precompiles, primitives::hardfork::SpecId};
+
+/// A set of Precompiles according to a spec.
+#[derive(Debug, Clone)]
+pub struct SpecPrecompiles<Spec> {
+    /// The configured precompiles.
+    ///
+    /// This is a cow so that this can be modified on demand.
+    precompiles: Cow<'static, Precompiles>,
+    /// The spec these precompiles belong to.
+    spec: Spec,
+}
+
+impl<Spec> SpecPrecompiles<Spec> {
+    /// Creates the [`SpecPrecompiles`] from a static reference.
+    pub const fn from_static(precompiles: &'static Precompiles, spec: Spec) -> Self {
+        Self { precompiles: Cow::Borrowed(precompiles), spec }
+    }
+
+    /// Creates a new set of precompiles for that spec.
+    pub fn new(precompiles: Cow<'static, Precompiles>, spec: Spec) -> Self {
+        Self { precompiles, spec }
+    }
+}
+
+impl From<EthPrecompiles> for SpecPrecompiles<SpecId> {
+    fn from(value: EthPrecompiles) -> Self {
+        Self::from_static(value.precompiles, value.spec)
+    }
+}

--- a/crates/evm/src/precompiles.rs
+++ b/crates/evm/src/precompiles.rs
@@ -30,7 +30,7 @@ impl<Spec> SpecPrecompiles<Spec> {
 
     /// Creates a new set of precompiles for a spec.
     pub fn new(precompiles: Cow<'static, Precompiles>, spec: Spec) -> Self {
-        Self { precompiles: as_dyn_precompiles(precompiles), spec }
+        Self { precompiles: into_dyn_precompiles(precompiles), spec }
     }
 
     /// Returns the configured precompiles as a read-only reference.
@@ -110,7 +110,7 @@ impl<Spec> SpecPrecompiles<Spec> {
 }
 
 /// Converts the given static precompiles into their dynamic representation.
-fn as_dyn_precompiles(precompiles: Cow<'static, Precompiles>) -> DynPrecompiles {
+fn into_dyn_precompiles(precompiles: Cow<'static, Precompiles>) -> DynPrecompiles {
     // Convert static precompiles to dynamic immediately
     let mut dynamic = DynPrecompiles::default();
 
@@ -148,7 +148,7 @@ where
             return false;
         }
 
-        self.precompiles = as_dyn_precompiles(Cow::Borrowed(Precompiles::new(
+        self.precompiles = into_dyn_precompiles(Cow::Borrowed(Precompiles::new(
             PrecompileSpecId::from_spec_id(spec.clone().into()),
         )));
         self.spec = spec;

--- a/crates/evm/src/precompiles.rs
+++ b/crates/evm/src/precompiles.rs
@@ -161,9 +161,9 @@ where
 #[derive(Clone, Default)]
 pub struct DynPrecompiles {
     /// Precompiles
-    pub inner: HashMap<Address, DynPrecompile>,
+    inner: HashMap<Address, DynPrecompile>,
     /// Addresses of precompile
-    pub addresses: HashSet<Address>,
+    addresses: HashSet<Address>,
 }
 
 impl core::fmt::Debug for DynPrecompiles {

--- a/crates/evm/src/precompiles.rs
+++ b/crates/evm/src/precompiles.rs
@@ -56,7 +56,7 @@ impl<Spec> SpecPrecompiles<Spec> {
         let precompiles = self.precompiles_mut();
 
         // Get the current precompile at the address
-        if let Some(dyn_precompile) = precompiles.inner.get(address).cloned() {
+        if let Some(dyn_precompile) = precompiles.inner.remove(address) {
             // Apply the transformation function
             let transformed = f(dyn_precompile);
 

--- a/crates/evm/src/precompiles.rs
+++ b/crates/evm/src/precompiles.rs
@@ -1,9 +1,15 @@
 //! Helpers for dealing with Precompiles.
 
-use alloc::borrow::Cow;
-use alloy_primitives::Address;
-use revm::{handler::EthPrecompiles, precompile::Precompiles, primitives::hardfork::SpecId};
-use revm::precompile::PrecompileFn;
+use alloc::{borrow::Cow, sync::Arc};
+use alloy_primitives::{
+    map::{HashMap, HashSet},
+    Address, Bytes,
+};
+use revm::{
+    handler::EthPrecompiles,
+    precompile::{PrecompileFn, PrecompileResult, Precompiles},
+    primitives::hardfork::SpecId,
+};
 
 /// A set of Precompiles according to a spec.
 #[derive(Debug, Clone)]
@@ -11,42 +17,43 @@ pub struct SpecPrecompiles<Spec> {
     /// The configured precompiles.
     ///
     /// This is a cow so that this can be modified on demand.
-    precompiles: Cow<'static, Precompiles>,
+    precompiles: PrecompilesMap,
     /// The spec these precompiles belong to.
     spec: Spec,
 }
 
-
 impl<Spec> SpecPrecompiles<Spec> {
     /// Creates the [`SpecPrecompiles`] from a static reference.
     pub const fn from_static(precompiles: &'static Precompiles, spec: Spec) -> Self {
-        Self { precompiles: Cow::Borrowed(precompiles), spec }
+        // Self { precompiles: Cow::Borrowed(precompiles), spec }
+        todo!()
     }
 
     /// Creates a new set of precompiles for that spec.
     pub fn new(precompiles: Cow<'static, Precompiles>, spec: Spec) -> Self {
-        Self { precompiles, spec }
+        todo!()
     }
-    
+
     /// Returns the configured precompiles
     pub fn precompiles(&self) -> &Precompiles {
-        &self.precompiles
+        todo!()
     }
-    
+
     /// Returns mutable access to the precompiles.
     pub fn precompiles_mut(&mut self) -> &mut Precompiles {
-        self.precompiles.to_mut()
+        todo!()
     }
-    
+
     /// Returns the configured spec.
     pub const fn spec(&self) -> &Spec {
         &self.spec
     }
-    
-    pub fn map_precompile<F>(&mut self, address: &Address, f: F) where F: Fn(PrecompileFn) -> PrecompileFn {
-        if let Some(precompile) = self.precompiles_mut().get(address) {
-            
-        }
+
+    pub fn map_precompile<F>(&mut self, address: &Address, f: F)
+    where
+        F: Fn(PrecompileFn) -> PrecompileFn,
+    {
+        if let Some(precompile) = self.precompiles_mut().get(address) {}
     }
 }
 
@@ -54,4 +61,24 @@ impl From<EthPrecompiles> for SpecPrecompiles<SpecId> {
     fn from(value: EthPrecompiles) -> Self {
         Self::from_static(value.precompiles, value.spec)
     }
+}
+
+enum PrecompilesMap {
+    Builtin(Cow<'static, Precompiles>),
+    Dynamic(PrecompilesMut),
+}
+
+#[derive(Clone)]
+pub struct DynPrecompile(pub(crate) Arc<dyn Precompile>);
+
+#[derive(Clone, Default)]
+struct PrecompilesMut {
+    /// Precompiles
+    inner: HashMap<Address, DynPrecompile>,
+    /// Addresses of precompile
+    addresses: HashSet<Address>,
+}
+
+pub trait Precompile {
+    fn call(&self, data: &Bytes, gas: u64) -> PrecompileResult;
 }

--- a/crates/evm/src/precompiles.rs
+++ b/crates/evm/src/precompiles.rs
@@ -157,7 +157,7 @@ impl From<EthPrecompiles> for PrecompilesMap {
     }
 }
 
-// TODO: uncomment when OpPrecompiles exposes precompiles.
+// TODO: uncomment when OpPrecompiles exposes precompiles https://github.com/bluealloy/revm/pull/2444
 //impl From<OpPrecompiles> for SpecPrecompiles {
 //    fn from(value: OpPrecompiles) -> Self {
 //        Self::from_static(value.precompiles())

--- a/crates/evm/src/precompiles.rs
+++ b/crates/evm/src/precompiles.rs
@@ -15,8 +15,6 @@ use revm::{
 #[derive(Debug, Clone)]
 pub struct SpecPrecompiles<Spec> {
     /// The configured precompiles.
-    ///
-    /// This is a cow so that this can be modified on demand.
     precompiles: PrecompilesMap,
     /// The spec these precompiles belong to.
     spec: Spec,
@@ -25,13 +23,12 @@ pub struct SpecPrecompiles<Spec> {
 impl<Spec> SpecPrecompiles<Spec> {
     /// Creates the [`SpecPrecompiles`] from a static reference.
     pub const fn from_static(precompiles: &'static Precompiles, spec: Spec) -> Self {
-        // Self { precompiles: Cow::Borrowed(precompiles), spec }
-        todo!()
+        Self { precompiles: PrecompilesMap::Builtin(Cow::Borrowed(precompiles)), spec }
     }
 
-    /// Creates a new set of precompiles for that spec.
+    /// Creates a new set of precompiles for a spec.
     pub fn new(precompiles: Cow<'static, Precompiles>, spec: Spec) -> Self {
-        todo!()
+        Self { precompiles: PrecompilesMap::Builtin(precompiles), spec }
     }
 
     /// Returns the configured precompiles
@@ -41,7 +38,22 @@ impl<Spec> SpecPrecompiles<Spec> {
 
     /// Returns mutable access to the precompiles.
     pub fn precompiles_mut(&mut self) -> &mut Precompiles {
-        todo!()
+        match &mut self.precompiles {
+            PrecompilesMap::Builtin(cow) => {
+                // Ensure we have a mutable Cow by cloning the borrowed data if needed
+                if let Cow::Borrowed(static_ref) = cow {
+                    *cow = Cow::Owned((*static_ref).clone());
+                }
+                // Now we definitely have an owned value
+                match cow {
+                    Cow::Owned(ref mut owned) => owned,
+                    Cow::Borrowed(_) => unreachable!("We just ensured we have an owned value"),
+                }
+            }
+            PrecompilesMap::Dynamic(_) => {
+                todo!()
+            }
+        }
     }
 
     /// Returns the configured spec.
@@ -49,11 +61,27 @@ impl<Spec> SpecPrecompiles<Spec> {
         &self.spec
     }
 
+    /// Maps a precompile at the given address using the provided function.
     pub fn map_precompile<F>(&mut self, address: &Address, f: F)
     where
-        F: Fn(PrecompileFn) -> PrecompileFn,
+        F: FnOnce(PrecompileFn) -> PrecompileFn + Send + Sync + 'static,
     {
-        if let Some(precompile) = self.precompiles_mut().get(address) {}
+        // Apply a transformation that converts to and from PrecompileFn
+        self.apply_precompile(address, |current| None);
+    }
+
+    /// Maps all precompiles using the provided function.
+    pub fn map_precompiles<F>(&mut self, mut f: F)
+    where
+        F: FnMut(&Address, DynPrecompile) -> DynPrecompile,
+    {
+    }
+
+    /// Applies a new precompile at the given address.
+    pub fn apply_precompile<F>(&mut self, address: &Address, f: F)
+    where
+        F: FnOnce(Option<DynPrecompile>) -> Option<DynPrecompile>,
+    {
     }
 }
 
@@ -63,13 +91,64 @@ impl From<EthPrecompiles> for SpecPrecompiles<SpecId> {
     }
 }
 
+#[derive(Clone)]
 enum PrecompilesMap {
     Builtin(Cow<'static, Precompiles>),
     Dynamic(PrecompilesMut),
 }
 
+impl core::fmt::Debug for PrecompilesMap {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Builtin(_) => f.debug_struct("PrecompilesMap::Builtin").finish(),
+            Self::Dynamic(precompiles) => f
+                .debug_struct("PrecompilesMap::Dynamic")
+                .field("addresses", &precompiles.addresses)
+                .finish(),
+        }
+    }
+}
+
+/// A dynamic precompile implementation that can be modified at runtime.
 #[derive(Clone)]
-pub struct DynPrecompile(pub(crate) Arc<dyn Precompile>);
+pub struct DynPrecompile(pub(crate) Arc<dyn Precompile + Send + Sync>);
+
+impl core::fmt::Debug for DynPrecompile {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DynPrecompile").finish()
+    }
+}
+
+impl Precompile for DynPrecompile {
+    fn call(&self, data: &Bytes, gas: u64) -> PrecompileResult {
+        self.0.call(data, gas)
+    }
+}
+
+impl From<PrecompileFn> for DynPrecompile {
+    fn from(f: PrecompileFn) -> Self {
+        // Create a wrapper struct to convert the function pointer to a dynamic trait object
+        struct PrecompileFnWrapper(PrecompileFn);
+
+        impl Precompile for PrecompileFnWrapper {
+            fn call(&self, data: &Bytes, gas: u64) -> PrecompileResult {
+                (self.0)(data, gas)
+            }
+        }
+
+        Self(Arc::new(PrecompileFnWrapper(f)))
+    }
+}
+
+impl DynPrecompile {
+    /// Wraps this precompile with a custom implementation.
+    pub fn wrap<P: Precompile + Send + Sync + 'static>(
+        self,
+        wrapper: impl FnOnce(Self) -> P,
+    ) -> Self {
+        Self(Arc::new(wrapper(self)))
+    }
+}
 
 #[derive(Clone, Default)]
 struct PrecompilesMut {
@@ -79,6 +158,14 @@ struct PrecompilesMut {
     addresses: HashSet<Address>,
 }
 
+impl core::fmt::Debug for PrecompilesMut {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PrecompilesMut").field("addresses", &self.addresses).finish()
+    }
+}
+
+/// Trait for implementing precompiled contracts.
 pub trait Precompile {
+    /// Execute the precompile with the given input data and gas limit.
     fn call(&self, data: &Bytes, gas: u64) -> PrecompileResult;
 }

--- a/crates/evm/src/precompiles.rs
+++ b/crates/evm/src/precompiles.rs
@@ -223,8 +223,7 @@ impl Precompile for DynPrecompile {
 
 impl<F> From<F> for DynPrecompile
 where
-    F: Precompile + Send + Sync + 'static,
-    F: Fn(&Bytes, u64) -> PrecompileResult,
+    F: Fn(&Bytes, u64) -> PrecompileResult + Precompile + Send + Sync + 'static,
 {
     fn from(f: F) -> Self {
         Self(Arc::new(f))

--- a/crates/evm/src/precompiles.rs
+++ b/crates/evm/src/precompiles.rs
@@ -1,6 +1,6 @@
 //! Helpers for dealing with Precompiles.
 
-use alloc::{borrow::Cow, boxed::Box, string::String, sync::Arc};
+use alloc::{borrow::Cow, boxed::Box, string::String, sync::Arc, vec::Vec};
 use alloy_primitives::{
     map::{HashMap, HashSet},
     Address, Bytes,


### PR DESCRIPTION
closes #70

instead of making possible to configure a custom precompiles provider on the factory level, we should instead make it possible to modify the precompiles via the evm on demand.

but we can also solve this with another constructor fn on EvmFactory, however, then we still need to use one specific PrecompileProvider type.

since this turned out to be a bit tricky with GATs, we can introduce our own Precompiles type that supports the usecases we want: hotswapping function pointers for example.

and we can offload all custom functionality directly into the precompile fn pointer instead of doing this: https://github.com/paradigmxyz/reth/pull/15536
