### PR TITLE
feat: include Precompiles associated type in Evm trait

### DIFF
--- a/crates/evm/src/eth/mod.rs
+++ b/crates/evm/src/eth/mod.rs
@@ -112,6 +112,7 @@ where
     type Error = EVMError<DB::Error>;
     type HaltReason = HaltReason;
     type Spec = SpecId;
+    type Precompiles = PRECOMPILE;
 
     fn block(&self) -> &BlockEnv {
         &self.block
@@ -205,6 +206,10 @@ where
 
     fn set_inspector_enabled(&mut self, enabled: bool) {
         self.inspect = enabled;
+    }
+
+    fn precompiles_mut(&mut self) -> &mut Self::Precompiles {
+        &mut self.inner.precompiles
     }
 }
 

--- a/crates/evm/src/evm.rs
+++ b/crates/evm/src/evm.rs
@@ -148,6 +148,7 @@ pub trait EvmFactory {
         HaltReason = Self::HaltReason,
         Error = Self::Error<DB::Error>,
         Spec = Self::Spec,
+        Precompiles = Self::Precompiles,
     >;
 
     /// The EVM context for inspectors
@@ -160,6 +161,8 @@ pub trait EvmFactory {
     type HaltReason: HaltReasonTr + Send + Sync + 'static;
     /// The EVM specification identifier, see [`Evm::Spec`].
     type Spec: Debug + Copy + Send + Sync + 'static;
+    /// Precompiles used by the EVM.
+    type Precompiles;
 
     /// Creates a new instance of an EVM.
     fn create_evm<DB: Database>(

--- a/crates/evm/src/evm.rs
+++ b/crates/evm/src/evm.rs
@@ -42,6 +42,8 @@ pub trait Evm {
     /// Identifier of the EVM specification. EVM is expected to use this identifier to determine
     /// which features are enabled.
     type Spec: Debug + Copy + Send + Sync + 'static;
+    /// Precompiles used by the EVM.
+    type Precompiles;
 
     /// Reference to [`BlockEnv`].
     fn block(&self) -> &BlockEnv;
@@ -132,6 +134,9 @@ pub trait Evm {
     fn disable_inspector(&mut self) {
         self.set_inspector_enabled(false)
     }
+
+    /// Mutable getter of precompiles.
+    fn precompiles_mut(&mut self) -> &mut Self::Precompiles;
 }
 
 /// A type responsible for creating instances of an ethereum virtual machine given a certain input.

--- a/crates/op-evm/src/lib.rs
+++ b/crates/op-evm/src/lib.rs
@@ -218,13 +218,14 @@ where
 pub struct OpEvmFactory;
 
 impl EvmFactory for OpEvmFactory {
-    type Evm<DB: Database, I: Inspector<OpContext<DB>>> = OpEvm<DB, I>;
+    type Evm<DB: Database, I: Inspector<OpContext<DB>>> = OpEvm<DB, I, Self::Precompiles>;
     type Context<DB: Database> = OpContext<DB>;
     type Tx = OpTransaction<TxEnv>;
     type Error<DBError: core::error::Error + Send + Sync + 'static> =
         EVMError<DBError, OpTransactionError>;
     type HaltReason = OpHaltReason;
     type Spec = OpSpecId;
+    type Precompiles = OpPrecompiles;
 
     fn create_evm<DB: Database>(
         &self,

--- a/crates/op-evm/src/lib.rs
+++ b/crates/op-evm/src/lib.rs
@@ -101,6 +101,7 @@ where
     type Error = EVMError<DB::Error, OpTransactionError>;
     type HaltReason = OpHaltReason;
     type Spec = OpSpecId;
+    type Precompiles = P;
 
     fn block(&self) -> &BlockEnv {
         &self.block
@@ -204,6 +205,10 @@ where
 
     fn set_inspector_enabled(&mut self, enabled: bool) {
         self.inspect = enabled;
+    }
+
+    fn precompiles_mut(&mut self) -> &mut Self::Precompiles {
+        &mut self.inner.0.precompiles
     }
 }
 


### PR DESCRIPTION
towards #70

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

After #71, which allowed modifying precompiles at runtime, we need to make the functionality accessible to evm consumers.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Adds a `Precompiles` associated type and a `precompiles_mut` method to the `Evm` trait.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
