### PR TITLE
feat: expose Inspector on Evm

### DIFF
--- a/crates/evm/src/eth/mod.rs
+++ b/crates/evm/src/eth/mod.rs
@@ -79,11 +79,6 @@ impl<DB: Database, I, PRECOMPILE> EthEvm<DB, I, PRECOMPILE> {
     pub fn ctx_mut(&mut self) -> &mut EthEvmContext<DB> {
         &mut self.inner.ctx
     }
-
-    /// Provides a mutable reference to the EVM inspector.
-    pub fn inspector_mut(&mut self) -> &mut I {
-        &mut self.inner.inspector
-    }
 }
 
 impl<DB: Database, I, PRECOMPILE> Deref for EthEvm<DB, I, PRECOMPILE> {

--- a/crates/evm/src/eth/mod.rs
+++ b/crates/evm/src/eth/mod.rs
@@ -114,6 +114,7 @@ where
     type HaltReason = HaltReason;
     type Spec = SpecId;
     type Precompiles = PRECOMPILE;
+    type Inspector = I;
 
     fn block(&self) -> &BlockEnv {
         &self.block
@@ -211,6 +212,10 @@ where
 
     fn precompiles_mut(&mut self) -> &mut Self::Precompiles {
         &mut self.inner.precompiles
+    }
+
+    fn inspector_mut(&mut self) -> &mut Self::Inspector {
+        &mut self.inner.inspector
     }
 }
 

--- a/crates/evm/src/evm.rs
+++ b/crates/evm/src/evm.rs
@@ -44,6 +44,8 @@ pub trait Evm {
     type Spec: Debug + Copy + Send + Sync + 'static;
     /// Precompiles used by the EVM.
     type Precompiles;
+    /// Evm inspector.
+    type Inspector;
 
     /// Reference to [`BlockEnv`].
     fn block(&self) -> &BlockEnv;
@@ -137,6 +139,9 @@ pub trait Evm {
 
     /// Mutable getter of precompiles.
     fn precompiles_mut(&mut self) -> &mut Self::Precompiles;
+
+    /// Mutable getter of inspector.
+    fn inspector_mut(&mut self) -> &mut Self::Inspector;
 }
 
 /// A type responsible for creating instances of an ethereum virtual machine given a certain input.
@@ -149,6 +154,7 @@ pub trait EvmFactory {
         Error = Self::Error<DB::Error>,
         Spec = Self::Spec,
         Precompiles = Self::Precompiles,
+        Inspector = I,
     >;
 
     /// The EVM context for inspectors

--- a/crates/op-evm/src/lib.rs
+++ b/crates/op-evm/src/lib.rs
@@ -102,6 +102,7 @@ where
     type HaltReason = OpHaltReason;
     type Spec = OpSpecId;
     type Precompiles = P;
+    type Inspector = I;
 
     fn block(&self) -> &BlockEnv {
         &self.block
@@ -209,6 +210,10 @@ where
 
     fn precompiles_mut(&mut self) -> &mut Self::Precompiles {
         &mut self.inner.0.precompiles
+    }
+
+    fn inspector_mut(&mut self) -> &mut Self::Inspector {
+        &mut self.inner.0.inspector
     }
 }
 

--- a/crates/op-evm/src/lib.rs
+++ b/crates/op-evm/src/lib.rs
@@ -54,11 +54,6 @@ impl<DB: Database, I, P> OpEvm<DB, I, P> {
     pub fn ctx_mut(&mut self) -> &mut OpContext<DB> {
         &mut self.inner.0.ctx
     }
-
-    /// Provides a mutable reference to the EVM inspector.
-    pub fn inspector_mut(&mut self) -> &mut I {
-        &mut self.inner.0.inspector
-    }
 }
 
 impl<DB: Database, I, P> OpEvm<DB, I, P> {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Closes #76 

Adds AT and mutable getter for inspector to `Evm` trait. Also locks the AT in `EvmFactory to the configured generic.`

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
