### PR TITLE
feat(eip7702): Delegate signer recovery to `alloy-consensus::crypto`

### DIFF
--- a/crates/evm/Cargo.toml
+++ b/crates/evm/Cargo.toml
@@ -14,9 +14,9 @@ repository.workspace = true
 workspace = true
 
 [dependencies]
+alloy-consensus = { workspace = true, features = ["k256"] }
 alloy-primitives.workspace = true
 alloy-sol-types.workspace = true
-alloy-consensus.workspace = true
 alloy-eips.workspace = true
 alloy-hardforks.workspace = true
 
@@ -34,15 +34,19 @@ serde_json.workspace = true
 
 [features]
 default = ["std"]
+secp256k1 = [
+    "std",
+    "alloy-consensus/secp256k1",
+]
 std = [
-	"alloy-primitives/std",
-	"revm/std",
-	"alloy-consensus/std",
-	"alloy-eips/std",
-	"alloy-sol-types/std",
-	"derive_more/std",
-	"op-revm?/std",
-	"thiserror/std",
-	"op-alloy-consensus?/std"
+    "alloy-primitives/std",
+    "revm/std",
+    "alloy-consensus/std",
+    "alloy-eips/std",
+    "alloy-sol-types/std",
+    "derive_more/std",
+    "op-revm?/std",
+    "thiserror/std",
+    "op-alloy-consensus?/std"
 ]
 op = ["op-revm", "op-alloy-consensus"]


### PR DESCRIPTION
Closes #75 

Leverages faster `secp256k1` crate based algorithm if `std` feature flag is on

## Motivation

The `alloy` have a new sender recovery algorithm using `secp256k1` crate. It was found in benchmarks that this crate's algorithm is significantly faster than the existing `k256`, but requires `std` making it usable only on platforms that allow it.

## Solution

Recover authority list of EIP-7702 transaction using the `alloy_consensus::crypto` module to recover the signer.

## PR Checklist

- [X] Added Tests
- [X] Added Documentation
- [X] Breaking changes
