### PR TITLE
fix: use HashMap::with_capacity_and_hasher

### DIFF
--- a/crates/evm/src/block/state_changes.rs
+++ b/crates/evm/src/block/state_changes.rs
@@ -62,7 +62,8 @@ pub fn post_block_withdrawals_balance_increments(
     block_timestamp: u64,
     withdrawals: &[Withdrawal],
 ) -> HashMap<Address, u128> {
-    let mut balance_increments = HashMap::with_capacity(withdrawals.len());
+    let mut balance_increments =
+        HashMap::with_capacity_and_hasher(withdrawals.len(), Default::default());
     insert_post_block_withdrawals_balance_increments(
         spec,
         block_timestamp,

--- a/crates/evm/src/precompiles.rs
+++ b/crates/evm/src/precompiles.rs
@@ -62,7 +62,8 @@ impl PrecompilesMap {
 
         // apply the transformation to each precompile
         let entries = dyn_precompiles.inner.drain();
-        let mut new_map = HashMap::with_capacity(entries.size_hint().0);
+        let mut new_map =
+            HashMap::with_capacity_and_hasher(entries.size_hint().0, Default::default());
         for (addr, precompile) in entries {
             let transformed = f(&addr, precompile);
             new_map.insert(addr, transformed);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

fixes errors like:
```
error[E0308]: mismatched types
   --> /home/fgimenez/.cargo/git/checkouts/evm-136cfc19c7c10910/198219d/crates/evm/src/block/state_changes.rs:70:9
    |
66  |     insert_post_block_withdrawals_balance_increments(
    |     ------------------------------------------------ arguments to this function are incorrect
...
70  |         &mut balance_increments,
    |         ^^^^^^^^^^^^^^^^^^^^^^^ expected `&mut HashMap<Address, u128, RandomState>`, found `&mut HashMap<_, _>`
    |
    = note: `std::hash::RandomState` and `RandomState` have similar names, but are actually distinct types
```

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
