### PR TITLE
fix: `r.as_ref()` the trait `AsRef<[_; 0]>` is not implemented for `[u8]`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ op-alloy-consensus = { version = "0.15", default-features = false }
 
 # revm
 revm = { version = "23.1.0", default-features = false }
-op-revm = { version = "4.0.1", default-features = false }
+op-revm = { version = "4.0.2", default-features = false }
 
 # misc
 auto_impl = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ op-alloy-consensus = { version = "0.15", default-features = false }
 
 # revm
 revm = { version = "23.1.0", default-features = false }
-op-revm = { version = "4.0.2", default-features = false }
+op-revm = { version = "4.0.1", default-features = false }
 
 # misc
 auto_impl = "1"

--- a/crates/evm/src/precompiles.rs
+++ b/crates/evm/src/precompiles.rs
@@ -1,7 +1,5 @@
 //! Helpers for dealing with Precompiles.
 
-use core::cell::Ref;
-
 use alloc::{borrow::Cow, boxed::Box, string::String, sync::Arc};
 use alloy_consensus::transaction::Either;
 use alloy_primitives::{

--- a/crates/evm/src/precompiles.rs
+++ b/crates/evm/src/precompiles.rs
@@ -190,11 +190,16 @@ impl<CTX: ContextTr> PrecompileProvider<CTX> for PrecompilesMap {
         };
 
         // Execute the precompile
-        let mut _guard: Option<Ref<'_, [u8]>> = None;
-        let input_bytes: &[u8] = match &inputs.input {
+        let r;
+        let input_bytes = match &inputs.input {
             CallInput::SharedBuffer(range) => {
-                _guard = context.local().shared_memory_buffer_slice(range.clone());
-                _guard.as_deref().unwrap_or(&[])
+                match context.local().shared_memory_buffer_slice(range.clone()) {
+                    Some(slice) => {
+                        r = slice;
+                        &*r
+                    }
+                    None => &[],
+                }
             }
             CallInput::Bytes(bytes) => bytes.as_ref(),
         };


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Whilst bumping to `alloy-evm` v0.7.1 I encountered this issue

This only occurs when `alloy-evm` is integrated (in this case Foundry); it is not raised when I clone and compile `alloy-evm` from source

![Screenshot from 2025-05-12 14-49-46](https://github.com/user-attachments/assets/1ce78953-b998-4c8b-8d38-1ad512e692e1)

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

I think this code is equivalent and resolves the compiler error downstream for Foundry

cc @mattsse / @klkvr 

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
