### PR TITLE
feat: extend Evm::Spec bounds with Hash and PartialEq

### DIFF
--- a/crates/evm/src/evm.rs
+++ b/crates/evm/src/evm.rs
@@ -166,7 +166,7 @@ pub trait EvmFactory {
     /// Halt reason. See [`Evm::HaltReason`].
     type HaltReason: HaltReasonTr + Send + Sync + 'static;
     /// The EVM specification identifier, see [`Evm::Spec`].
-    type Spec: Debug + Copy + Send + Sync + 'static;
+    type Spec: Debug + Copy + Hash + PartialEq + Send + Sync + 'static;
     /// Precompiles used by the EVM.
     type Precompiles;
 

--- a/crates/evm/src/evm.rs
+++ b/crates/evm/src/evm.rs
@@ -41,7 +41,7 @@ pub trait Evm {
     type HaltReason: HaltReasonTr + Send + Sync + 'static;
     /// Identifier of the EVM specification. EVM is expected to use this identifier to determine
     /// which features are enabled.
-    type Spec: Debug + Copy + Hash + Eq + Send + Sync + 'static;
+    type Spec: Debug + Copy + Hash + Eq + Send + Sync + Default + 'static;
     /// Precompiles used by the EVM.
     type Precompiles;
     /// Evm inspector.
@@ -166,7 +166,7 @@ pub trait EvmFactory {
     /// Halt reason. See [`Evm::HaltReason`].
     type HaltReason: HaltReasonTr + Send + Sync + 'static;
     /// The EVM specification identifier, see [`Evm::Spec`].
-    type Spec: Debug + Copy + Hash + Eq + Send + Sync + 'static;
+    type Spec: Debug + Copy + Hash + Eq + Send + Sync + Default + 'static;
     /// Precompiles used by the EVM.
     type Precompiles;
 

--- a/crates/evm/src/evm.rs
+++ b/crates/evm/src/evm.rs
@@ -2,7 +2,7 @@
 
 use crate::{EvmEnv, EvmError, IntoTxEnv};
 use alloy_primitives::{Address, Bytes};
-use core::{error::Error, fmt::Debug};
+use core::{error::Error, fmt::Debug, hash::Hash};
 use revm::{
     context::{result::ExecutionResult, BlockEnv},
     context_interface::{
@@ -41,7 +41,7 @@ pub trait Evm {
     type HaltReason: HaltReasonTr + Send + Sync + 'static;
     /// Identifier of the EVM specification. EVM is expected to use this identifier to determine
     /// which features are enabled.
-    type Spec: Debug + Copy + Send + Sync + 'static;
+    type Spec: Debug + Copy + Hash + PartialEq + Send + Sync + 'static;
     /// Precompiles used by the EVM.
     type Precompiles;
     /// Evm inspector.

--- a/crates/evm/src/evm.rs
+++ b/crates/evm/src/evm.rs
@@ -41,7 +41,7 @@ pub trait Evm {
     type HaltReason: HaltReasonTr + Send + Sync + 'static;
     /// Identifier of the EVM specification. EVM is expected to use this identifier to determine
     /// which features are enabled.
-    type Spec: Debug + Copy + Hash + PartialEq + Send + Sync + 'static;
+    type Spec: Debug + Copy + Hash + Eq + Send + Sync + 'static;
     /// Precompiles used by the EVM.
     type Precompiles;
     /// Evm inspector.
@@ -166,7 +166,7 @@ pub trait EvmFactory {
     /// Halt reason. See [`Evm::HaltReason`].
     type HaltReason: HaltReasonTr + Send + Sync + 'static;
     /// The EVM specification identifier, see [`Evm::Spec`].
-    type Spec: Debug + Copy + Hash + PartialEq + Send + Sync + 'static;
+    type Spec: Debug + Copy + Hash + Eq + Send + Sync + 'static;
     /// Precompiles used by the EVM.
     type Precompiles;
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

We need to include EVM's `Spec` AT  in reth's precompile cache key for https://github.com/paradigmxyz/reth/issues/16207 this PR adds the missing bounds required

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
