### PR TITLE
feat: add non-mutable getters for `inspector` and `precompiles`

### DIFF
--- a/crates/evm/src/either.rs
+++ b/crates/evm/src/either.rs
@@ -101,8 +101,16 @@ where
         either::for_both!(self, evm => evm.disable_inspector())
     }
 
+    fn precompiles(&self) -> &Self::Precompiles {
+        either::for_both!(self, evm => evm.precompiles())
+    }
+
     fn precompiles_mut(&mut self) -> &mut Self::Precompiles {
         either::for_both!(self, evm => evm.precompiles_mut())
+    }
+
+    fn inspector(&self) -> &Self::Inspector {
+        either::for_both!(self, evm => evm.inspector())
     }
 
     fn inspector_mut(&mut self) -> &mut Self::Inspector {

--- a/crates/evm/src/eth/mod.rs
+++ b/crates/evm/src/eth/mod.rs
@@ -205,8 +205,16 @@ where
         self.inspect = enabled;
     }
 
+    fn precompiles(&self) -> &Self::Precompiles {
+        &self.inner.precompiles
+    }
+
     fn precompiles_mut(&mut self) -> &mut Self::Precompiles {
         &mut self.inner.precompiles
+    }
+
+    fn inspector(&self) -> &Self::Inspector {
+        &self.inner.inspector
     }
 
     fn inspector_mut(&mut self) -> &mut Self::Inspector {

--- a/crates/evm/src/evm.rs
+++ b/crates/evm/src/evm.rs
@@ -137,8 +137,14 @@ pub trait Evm {
         self.set_inspector_enabled(false)
     }
 
+    /// Getter of precompiles.
+    fn precompiles(&self) -> &Self::Precompiles;
+
     /// Mutable getter of precompiles.
     fn precompiles_mut(&mut self) -> &mut Self::Precompiles;
+
+    /// Getter of inspector.
+    fn inspector(&self) -> &Self::Inspector;
 
     /// Mutable getter of inspector.
     fn inspector_mut(&mut self) -> &mut Self::Inspector;

--- a/crates/op-evm/src/lib.rs
+++ b/crates/op-evm/src/lib.rs
@@ -203,8 +203,16 @@ where
         self.inspect = enabled;
     }
 
+    fn precompiles(&self) -> &Self::Precompiles {
+        &self.inner.0.precompiles
+    }
+
     fn precompiles_mut(&mut self) -> &mut Self::Precompiles {
         &mut self.inner.0.precompiles
+    }
+
+    fn inspector(&self) -> &Self::Inspector {
+        &self.inner.0.inspector
     }
 
     fn inspector_mut(&mut self) -> &mut Self::Inspector {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Encountered a case where I want to access a field on the`inspector` without it needing to be mutable. For code hygiene purposes accessing it non-mutable would be preferred (see: https://github.com/foundry-rs/foundry/pull/10555)

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Adds non-mutable getters for `precompiles` and `inspector` mirroring the current `precompiles_mut` and `inspector_mut`

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes