### PR TITLE
feat: move map_precompiles to trait to allow precompile customization

### DIFF
--- a/crates/evm/src/eth/mod.rs
+++ b/crates/evm/src/eth/mod.rs
@@ -228,13 +228,13 @@ where
 pub struct EthEvmFactory;
 
 impl EvmFactory for EthEvmFactory {
-    type Evm<DB: Database, I: Inspector<EthEvmContext<DB>>> = EthEvm<DB, I, Self::Precompiles>;
+    type Evm<DB: Database, I: Inspector<EthEvmContext<DB>>> = EthEvm<DB, I, Self::Precompiles<DB>>;
     type Context<DB: Database> = Context<BlockEnv, TxEnv, CfgEnv, DB>;
     type Tx = TxEnv;
     type Error<DBError: core::error::Error + Send + Sync + 'static> = EVMError<DBError>;
     type HaltReason = HaltReason;
     type Spec = SpecId;
-    type Precompiles = PrecompilesMap;
+    type Precompiles<DB: Database> = PrecompilesMap;
 
     fn create_evm<DB: Database>(&self, db: DB, input: EvmEnv) -> Self::Evm<DB, NoOpInspector> {
         let spec_id = input.cfg_env.spec;

--- a/crates/evm/src/precompiles.rs
+++ b/crates/evm/src/precompiles.rs
@@ -107,7 +107,7 @@ impl PrecompilesMap {
 
 /// Abstracts away the functions needed to map a precompile to an address
 /// These functions are used by Reth (etc.) to configure precompiles
-/// Abstracting it to a trait allows more control over hoe precompiles work
+/// Abstracting it to a trait allows more control over how precompiles work
 pub trait PrecompileCfg {
     /// Maps a precompile at the given address using the provided function.
     fn map_precompile<F>(&mut self, address: &Address, f: F)

--- a/crates/op-evm/src/lib.rs
+++ b/crates/op-evm/src/lib.rs
@@ -226,14 +226,14 @@ where
 pub struct OpEvmFactory;
 
 impl EvmFactory for OpEvmFactory {
-    type Evm<DB: Database, I: Inspector<OpContext<DB>>> = OpEvm<DB, I, Self::Precompiles>;
+    type Evm<DB: Database, I: Inspector<OpContext<DB>>> = OpEvm<DB, I, Self::Precompiles<DB>>;
     type Context<DB: Database> = OpContext<DB>;
     type Tx = OpTransaction<TxEnv>;
     type Error<DBError: core::error::Error + Send + Sync + 'static> =
         EVMError<DBError, OpTransactionError>;
     type HaltReason = OpHaltReason;
     type Spec = OpSpecId;
-    type Precompiles = PrecompilesMap;
+    type Precompiles<DB: Database> = PrecompilesMap;
 
     fn create_evm<DB: Database>(
         &self,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Replacing the hardcoded PrecompilesMap with the impl representations allows us to drop the hardcoded PrecompilesMap in reth's ConfigureEvm. This helps to extend the precompile's usecase to allow custom processing. Currently the PrecompileProvider, despite implementation, isn't used for custom precompiles (which was allowed earlier).

Related discussion: https://github.com/paradigmxyz/reth/discussions/16825

## Solution

Created a new trait called `PrecompileCfg` which includes the functions used by reth to set the precompiles.

## PR Checklist

- [ ] Added Tests
- [x] Added Documentation
- [x] Breaking changes
