### PR TITLE
fix: `the trait bound `[u8]: AsRef<[_; 0]>` is not satisfied` in `precompiles`

### DIFF
--- a/crates/evm/src/precompiles.rs
+++ b/crates/evm/src/precompiles.rs
@@ -236,7 +236,7 @@ impl<CTX: ContextTr> PrecompileProvider<CTX> for PrecompilesMap {
                 #[allow(clippy::option_if_let_else)]
                 if let Some(slice) = context.local().shared_memory_buffer_slice(range.clone()) {
                     r = slice;
-                    r.as_ref()
+                    &r[..]
                 } else {
                     &[]
                 }

--- a/crates/evm/src/precompiles.rs
+++ b/crates/evm/src/precompiles.rs
@@ -236,7 +236,7 @@ impl<CTX: ContextTr> PrecompileProvider<CTX> for PrecompilesMap {
                 #[allow(clippy::option_if_let_else)]
                 if let Some(slice) = context.local().shared_memory_buffer_slice(range.clone()) {
                     r = slice;
-                    &r[..]
+                    &*r
                 } else {
                     &[]
                 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

As raised here: https://github.com/alloy-rs/evm/pull/100#discussion_r2163451799 looks to be a regression of https://github.com/alloy-rs/evm/pull/86 during port to revm 26

In Foundry we are getting the following error on the `r.as_ref()` line: https://github.com/alloy-rs/evm/blob/5ed2c8e435aa7e2a14c20b99b669fccd28fc198d/crates/evm/src/precompiles.rs#L239 when using the library in https://github.com/foundry-rs/foundry/tree/zerosnacks/bump-revm-26.0.0:

```
the trait bound `[u8]: AsRef<[_; 0]>` is not satisfied
the following other types implement trait `AsRef<T>`:
  `[u8]` implements `AsRef<winnow::stream::bstr::BStr>`
  `[u8]` implements `AsRef<winnow::stream::bytes::Bytes>`
```

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Fixes type mismatch, turns it into a `&[u8]`

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
