### PR TITLE
feat: add BlockEnv to EvmInternals

### DIFF
--- a/crates/evm/src/precompiles.rs
+++ b/crates/evm/src/precompiles.rs
@@ -298,7 +298,7 @@ where
             gas: gas_limit,
             caller: inputs.caller_address,
             value: inputs.call_value,
-            internals: EvmInternals::new(journal),
+            internals: EvmInternals::new(journal, &context.block),
         });
 
         match precompile_result {
@@ -440,7 +440,7 @@ mod tests {
     use super::*;
     use crate::eth::EthEvmContext;
     use alloy_primitives::{address, Bytes};
-    use revm::{context::ContextTr, database::EmptyDB, precompile::PrecompileOutput};
+    use revm::{context::Block, database::EmptyDB, precompile::PrecompileOutput};
 
     #[test]
     fn test_map_precompile() {
@@ -471,7 +471,7 @@ mod tests {
                 gas: gas_limit,
                 caller: Address::ZERO,
                 value: U256::ZERO,
-                internals: EvmInternals::new(ctx.journal_mut()),
+                internals: EvmInternals::new(&mut ctx.journaled_state, &ctx.block),
             })
             .unwrap();
         assert_eq!(result.bytes, test_input, "Identity precompile should return the input data");
@@ -503,7 +503,7 @@ mod tests {
                 gas: gas_limit,
                 caller: Address::ZERO,
                 value: U256::ZERO,
-                internals: EvmInternals::new(ctx.journal_mut()),
+                internals: EvmInternals::new(&mut ctx.journaled_state, &ctx.block),
             })
             .unwrap();
         assert_eq!(
@@ -522,6 +522,7 @@ mod tests {
 
         // define a closure that implements the precompile functionality
         let closure_precompile = |input: PrecompileInput<'_>| -> PrecompileResult {
+            let _timestamp = input.internals.block_env().timestamp();
             let mut output = b"processed: ".to_vec();
             output.extend_from_slice(input.data.as_ref());
             Ok(PrecompileOutput { gas_used: 15, bytes: Bytes::from(output) })
@@ -535,7 +536,7 @@ mod tests {
                 gas: gas_limit,
                 caller: Address::ZERO,
                 value: U256::ZERO,
-                internals: EvmInternals::new(ctx.journal_mut()),
+                internals: EvmInternals::new(&mut ctx.journaled_state, &ctx.block),
             })
             .unwrap();
         assert_eq!(result.gas_used, 15);
@@ -563,7 +564,7 @@ mod tests {
                 gas: gas_limit,
                 caller: Address::ZERO,
                 value: U256::ZERO,
-                internals: EvmInternals::new(ctx.journal_mut()),
+                internals: EvmInternals::new(&mut ctx.journaled_state, &ctx.block),
             })
             .unwrap();
         assert_eq!(result.bytes, test_input, "Identity precompile should return the input data");
@@ -590,7 +591,7 @@ mod tests {
                 gas: gas_limit,
                 caller: Address::ZERO,
                 value: U256::ZERO,
-                internals: EvmInternals::new(ctx.journal_mut()),
+                internals: EvmInternals::new(&mut ctx.journaled_state, &ctx.block),
             })
             .unwrap();
         assert_eq!(

--- a/crates/evm/src/traits.rs
+++ b/crates/evm/src/traits.rs
@@ -3,9 +3,9 @@
 use crate::Database;
 use alloc::boxed::Box;
 use alloy_primitives::{Address, B256};
-use core::{error::Error, fmt::Debug};
+use core::{error::Error, fmt, fmt::Debug};
 use revm::{
-    context::{DBErrorMarker, JournalTr},
+    context::{Block, DBErrorMarker, JournalTr},
     interpreter::{SStoreResult, StateLoad},
     primitives::{StorageKey, StorageValue},
     state::{Account, AccountInfo, Bytecode},
@@ -148,19 +148,24 @@ where
     }
 }
 
-/// Helper type exposing hooks into EVM.
-#[derive(Debug)]
+/// Helper type exposing hooks into EVM and access to evm internal settings.
 pub struct EvmInternals<'a> {
     internals: Box<dyn EvmInternalsTr + 'a>,
+    block_env: &'a (dyn Block + 'a),
 }
 
 impl<'a> EvmInternals<'a> {
     /// Creates a new [`EvmInternals`] instance.
-    pub fn new<T>(journal: &'a mut T) -> Self
+    pub(crate) fn new<T>(journal: &'a mut T, block_env: &'a dyn Block) -> Self
     where
         T: JournalTr<Database: Database> + Debug,
     {
-        Self { internals: Box::new(EvmInternalsImpl(journal)) }
+        Self { internals: Box::new(EvmInternalsImpl(journal)), block_env }
+    }
+
+    /// Returns the  evm's block information.
+    pub const fn block_env(&self) -> impl Block + 'a {
+        self.block_env
     }
 
     /// Returns a mutable reference to [`Database`] implementation with erased error type.
@@ -214,5 +219,14 @@ impl<'a> EvmInternals<'a> {
         value: StorageValue,
     ) -> Result<StateLoad<SStoreResult>, EvmInternalsError> {
         self.internals.sstore(address, key, value)
+    }
+}
+
+impl<'a> fmt::Debug for EvmInternals<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("EvmInternals")
+            .field("internals", &self.internals)
+            .field("block_env", &"{{}}")
+            .finish_non_exhaustive()
     }
 }

--- a/crates/evm/src/traits.rs
+++ b/crates/evm/src/traits.rs
@@ -2,7 +2,7 @@
 
 use crate::Database;
 use alloc::boxed::Box;
-use alloy_primitives::{Address, B256};
+use alloy_primitives::{Address, B256, U256};
 use core::{error::Error, fmt, fmt::Debug};
 use revm::{
     context::{Block, DBErrorMarker, JournalTr},
@@ -166,6 +166,16 @@ impl<'a> EvmInternals<'a> {
     /// Returns the  evm's block information.
     pub const fn block_env(&self) -> impl Block + 'a {
         self.block_env
+    }
+
+    /// Returns the current block number.
+    pub fn block_number(&self) -> U256 {
+        self.block_env.number()
+    }
+
+    /// Returns the current block timestamp.
+    pub fn block_timestamp(&self) -> U256 {
+        self.block_env.timestamp()
     }
 
     /// Returns a mutable reference to [`Database`] implementation with erased error type.


### PR DESCRIPTION
this way precompiles can access the block context such as timestamp number etc.