### PR TITLE
feat: make fusing optional in `TxTracer`

### DIFF
--- a/crates/evm/src/either.rs
+++ b/crates/evm/src/either.rs
@@ -54,10 +54,6 @@ where
         either::for_both!(self, evm => evm.transact_system_call(caller, contract, data))
     }
 
-    fn db_mut(&mut self) -> &mut Self::DB {
-        either::for_both!(self, evm => evm.db_mut())
-    }
-
     fn transact_commit(
         &mut self,
         tx: impl crate::IntoTxEnv<Self::Tx>,
@@ -101,19 +97,11 @@ where
         either::for_both!(self, evm => evm.disable_inspector())
     }
 
-    fn precompiles(&self) -> &Self::Precompiles {
-        either::for_both!(self, evm => evm.precompiles())
+    fn components(&self) -> (&Self::DB, &Self::Inspector, &Self::Precompiles) {
+        either::for_both!(self, evm => evm.components())
     }
 
-    fn precompiles_mut(&mut self) -> &mut Self::Precompiles {
-        either::for_both!(self, evm => evm.precompiles_mut())
-    }
-
-    fn inspector(&self) -> &Self::Inspector {
-        either::for_both!(self, evm => evm.inspector())
-    }
-
-    fn inspector_mut(&mut self) -> &mut Self::Inspector {
-        either::for_both!(self, evm => evm.inspector_mut())
+    fn components_mut(&mut self) -> (&mut Self::DB, &mut Self::Inspector, &mut Self::Precompiles) {
+        either::for_both!(self, evm => evm.components_mut())
     }
 }

--- a/crates/evm/src/eth/mod.rs
+++ b/crates/evm/src/eth/mod.rs
@@ -200,10 +200,6 @@ where
         res
     }
 
-    fn db_mut(&mut self) -> &mut Self::DB {
-        &mut self.journaled_state.database
-    }
-
     fn finish(self) -> (Self::DB, EvmEnv<Self::Spec>) {
         let Context { block: block_env, cfg: cfg_env, journaled_state, .. } = self.inner.ctx;
 
@@ -214,20 +210,16 @@ where
         self.inspect = enabled;
     }
 
-    fn precompiles(&self) -> &Self::Precompiles {
-        &self.inner.precompiles
+    fn components(&self) -> (&Self::DB, &Self::Inspector, &Self::Precompiles) {
+        (&self.inner.ctx.journaled_state.database, &self.inner.inspector, &self.inner.precompiles)
     }
 
-    fn precompiles_mut(&mut self) -> &mut Self::Precompiles {
-        &mut self.inner.precompiles
-    }
-
-    fn inspector(&self) -> &Self::Inspector {
-        &self.inner.inspector
-    }
-
-    fn inspector_mut(&mut self) -> &mut Self::Inspector {
-        &mut self.inner.inspector
+    fn components_mut(&mut self) -> (&mut Self::DB, &mut Self::Inspector, &mut Self::Precompiles) {
+        (
+            &mut self.inner.ctx.journaled_state.database,
+            &mut self.inner.inspector,
+            &mut self.inner.precompiles,
+        )
     }
 }
 

--- a/crates/evm/src/evm.rs
+++ b/crates/evm/src/evm.rs
@@ -100,8 +100,15 @@ pub trait Evm {
         data: Bytes,
     ) -> Result<ResultAndState<Self::HaltReason>, Self::Error>;
 
+    /// Returns an immutable reference to the underlying database.
+    fn db(&self) -> &Self::DB {
+        self.components().0
+    }
+
     /// Returns a mutable reference to the underlying database.
-    fn db_mut(&mut self) -> &mut Self::DB;
+    fn db_mut(&mut self) -> &mut Self::DB {
+        self.components_mut().0
+    }
 
     /// Executes a transaction and commits the state changes to the underlying database.
     fn transact_commit(
@@ -158,16 +165,30 @@ pub trait Evm {
     }
 
     /// Getter of precompiles.
-    fn precompiles(&self) -> &Self::Precompiles;
+    fn precompiles(&self) -> &Self::Precompiles {
+        self.components().2
+    }
 
     /// Mutable getter of precompiles.
-    fn precompiles_mut(&mut self) -> &mut Self::Precompiles;
+    fn precompiles_mut(&mut self) -> &mut Self::Precompiles {
+        self.components_mut().2
+    }
 
     /// Getter of inspector.
-    fn inspector(&self) -> &Self::Inspector;
+    fn inspector(&self) -> &Self::Inspector {
+        self.components().1
+    }
 
     /// Mutable getter of inspector.
-    fn inspector_mut(&mut self) -> &mut Self::Inspector;
+    fn inspector_mut(&mut self) -> &mut Self::Inspector {
+        self.components_mut().1
+    }
+
+    /// Provides immutable references to the database, inspector and precompiles.
+    fn components(&self) -> (&Self::DB, &Self::Inspector, &Self::Precompiles);
+
+    /// Provides mutable references to the database, inspector and precompiles.
+    fn components_mut(&mut self) -> (&mut Self::DB, &mut Self::Inspector, &mut Self::Precompiles);
 }
 
 /// A type responsible for creating instances of an ethereum virtual machine given a certain input.

--- a/crates/evm/src/tracing.rs
+++ b/crates/evm/src/tracing.rs
@@ -25,9 +25,18 @@ pub struct TracingCtx<'a, T, E: Evm> {
     /// State changes after transaction.
     pub state: &'a EvmState,
     /// Inspector state after transaction.
-    pub inspector: E::Inspector,
+    pub inspector: &'a mut E::Inspector,
     /// Database used when executing the transaction, _before_ committing the state changes.
     pub db: &'a mut E::DB,
+    /// Fused inspector.
+    fused_inspector: &'a E::Inspector,
+}
+
+impl<'a, T, E: Evm<Inspector: Clone>> TracingCtx<'a, T, E> {
+    /// Fuses the inspector and returns the current inspector state.
+    pub fn take_inspector(&mut self) -> E::Inspector {
+        core::mem::replace(self.inspector, self.fused_inspector.clone())
+    }
 }
 
 /// Output of tracing a transaction.
@@ -87,7 +96,13 @@ impl<E: Evm<Inspector: Clone, DB: DatabaseCommit>> TxTracer<E> {
         F: FnMut(TracingCtx<'_, T, E>) -> Result<O, Err>,
         Err: From<E::Error>,
     {
-        TracerIter { inner: self, txs: txs.into_iter().peekable(), hook, skip_last_commit: true }
+        TracerIter {
+            inner: self,
+            txs: txs.into_iter().peekable(),
+            hook,
+            skip_last_commit: true,
+            fuse: true,
+        }
     }
 }
 
@@ -99,6 +114,7 @@ pub struct TracerIter<'a, E: Evm, Txs: Iterator, F> {
     txs: Peekable<Txs>,
     hook: F,
     skip_last_commit: bool,
+    fuse: bool,
 }
 
 impl<E: Evm, Txs: Iterator, F> TracerIter<'_, E, Txs, F> {
@@ -108,6 +124,12 @@ impl<E: Evm, Txs: Iterator, F> TracerIter<'_, E, Txs, F> {
     /// interested in tracer output rather than in a state after it.
     pub fn commit_last_tx(mut self) -> Self {
         self.skip_last_commit = false;
+        self
+    }
+
+    /// Disables inspector fusing on every transaction and expects user to fuse it manually.
+    pub fn no_fuse(mut self) -> Self {
+        self.fuse = false;
         self
     }
 }
@@ -126,7 +148,9 @@ where
         let tx = self.txs.next()?;
         let result = self.inner.evm.transact(tx.clone());
 
-        let inspector = self.inner.fuse_inspector();
+        let TxTracer { evm, fused_inspector } = self.inner;
+        let (db, inspector, _) = evm.components_mut();
+
         let Ok(ResultAndState { result, state }) = result else {
             return None;
         };
@@ -135,13 +159,18 @@ where
             result,
             state: &state,
             inspector,
-            db: self.inner.evm.db_mut(),
+            db,
+            fused_inspector: &*fused_inspector,
         });
 
         // Only commit next transaction if `skip_last_commit` is disabled or there is a next
         // transaction.
         if !self.skip_last_commit || self.txs.peek().is_some() {
-            self.inner.evm.db_mut().commit(state);
+            db.commit(state);
+        }
+
+        if self.fuse {
+            self.inner.fuse_inspector();
         }
 
         Some(output)

--- a/crates/op-evm/src/lib.rs
+++ b/crates/op-evm/src/lib.rs
@@ -188,10 +188,6 @@ where
         res
     }
 
-    fn db_mut(&mut self) -> &mut Self::DB {
-        &mut self.journaled_state.database
-    }
-
     fn finish(self) -> (Self::DB, EvmEnv<Self::Spec>) {
         let Context { block: block_env, cfg: cfg_env, journaled_state, .. } = self.inner.0.ctx;
 
@@ -202,20 +198,20 @@ where
         self.inspect = enabled;
     }
 
-    fn precompiles(&self) -> &Self::Precompiles {
-        &self.inner.0.precompiles
+    fn components(&self) -> (&Self::DB, &Self::Inspector, &Self::Precompiles) {
+        (
+            &self.inner.0.ctx.journaled_state.database,
+            &self.inner.0.inspector,
+            &self.inner.0.precompiles,
+        )
     }
 
-    fn precompiles_mut(&mut self) -> &mut Self::Precompiles {
-        &mut self.inner.0.precompiles
-    }
-
-    fn inspector(&self) -> &Self::Inspector {
-        &self.inner.0.inspector
-    }
-
-    fn inspector_mut(&mut self) -> &mut Self::Inspector {
-        &mut self.inner.0.inspector
+    fn components_mut(&mut self) -> (&mut Self::DB, &mut Self::Inspector, &mut Self::Precompiles) {
+        (
+            &mut self.inner.0.ctx.journaled_state.database,
+            &mut self.inner.0.inspector,
+            &mut self.inner.0.precompiles,
+        )
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Closes #130 

## Solution

Adds `no_fuse` method to `TracerIter` that allows to disable fusing of inspector and rely on user to do it manually.

Changes `Evm` trait to expose just `components` and `components_mut` allowing to borrow all components at the same time instead of requiring all implementations to define separate getters for db/inspector/precompiles

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
