### PR TITLE
feat: Introduced Initializers to trace inspector

### DIFF
--- a/crates/evm/src/tracing.rs
+++ b/crates/evm/src/tracing.rs
@@ -1,3 +1,191 @@
+// //! Helpers for tracing.
+
+// use crate::{Evm, IntoTxEnv};
+// use core::{fmt::Debug, iter::Peekable};
+// use revm::{
+//     context::result::{ExecutionResult, ResultAndState},
+//     state::EvmState,
+//     DatabaseCommit,
+// };
+
+// /// A helper type for tracing transactions.
+// #[derive(Debug, Clone)]
+// pub struct TxTracer<E: Evm> {
+//     evm: E,
+//     fused_inspector: E::Inspector,
+// }
+
+// /// Container type for context exposed in [`TxTracer`].
+// #[derive(Debug)]
+// pub struct TracingCtx<'a, T, E: Evm> {
+//     /// The transaction that was just executed.
+//     pub tx: T,
+//     /// Result of transaction execution.
+//     pub result: ExecutionResult<E::HaltReason>,
+//     /// State changes after transaction.
+//     pub state: &'a EvmState,
+//     /// Inspector state after transaction.
+//     pub inspector: &'a mut E::Inspector,
+//     /// Database used when executing the transaction, _before_ committing the state changes.
+//     pub db: &'a mut E::DB,
+//     /// Fused inspector.
+//     fused_inspector: &'a E::Inspector,
+//     /// Whether the inspector was fused.
+//     was_fused: &'a mut bool,
+// }
+
+// impl<'a, T, E: Evm<Inspector: Clone>> TracingCtx<'a, T, E> {
+//     /// Fuses the inspector and returns the current inspector state.
+//     pub fn take_inspector(&mut self) -> E::Inspector {
+//         *self.was_fused = true;
+//         core::mem::replace(self.inspector, self.fused_inspector.clone())
+//     }
+// }
+
+// impl<E: Evm<Inspector: Clone, DB: DatabaseCommit>> TxTracer<E> {
+//     /// Creates a new [`TxTracer`] instance.
+//     pub fn new(mut evm: E) -> Self {
+//         Self { fused_inspector: evm.inspector_mut().clone(), evm }
+//     }
+
+//     fn fuse_inspector(&mut self) -> E::Inspector {
+//         core::mem::replace(self.evm.inspector_mut(), self.fused_inspector.clone())
+//     }
+
+//     /// Executes a transaction, and returns its outcome along with the inspector state.
+//     pub fn trace(
+//         &mut self,
+//         tx: impl IntoTxEnv<E::Tx>,
+//     ) -> Result<TraceOutput<E::HaltReason, E::Inspector>, E::Error> {
+//         let result = self.evm.transact_commit(tx);
+//         let inspector = self.fuse_inspector();
+//         Ok(TraceOutput { result: result?, inspector })
+//     }
+
+//     /// Executes multiple transactions, applies the closure to each transaction result, and returns
+//     /// the outcomes.
+//     #[expect(clippy::type_complexity)]
+//     pub fn trace_many<Txs, T, F, O>(
+//         &mut self,
+//         txs: Txs,
+//         mut f: F,
+//     ) -> TracerIter<'_, E, Txs::IntoIter, impl FnMut(TracingCtx<'_, T, E>) -> Result<O, E::Error>>
+//     where
+//         T: IntoTxEnv<E::Tx> + Clone,
+//         Txs: IntoIterator<Item = T>,
+//         F: FnMut(TracingCtx<'_, Txs::Item, E>) -> O,
+//     {
+//         self.try_trace_many(txs, move |ctx| Ok(f(ctx)))
+//     }
+
+//     /// Same as [`TxTracer::trace_many`], but operates on closures returning [`Result`]s.
+//     pub fn try_trace_many<Txs, T, F, O, Err>(
+//         &mut self,
+//         txs: Txs,
+//         hook: F,
+//     ) -> TracerIter<'_, E, Txs::IntoIter, F>
+//     where
+//         T: IntoTxEnv<E::Tx> + Clone,
+//         Txs: IntoIterator<Item = T>,
+//         F: FnMut(TracingCtx<'_, T, E>) -> Result<O, Err>,
+//         Err: From<E::Error>,
+//     {
+//         TracerIter {
+//             inner: self,
+//             txs: txs.into_iter().peekable(),
+//             hook,
+//             skip_last_commit: true,
+//             fuse: true,
+//         }
+//     }
+// }
+
+// /// Output of tracing a transaction.
+// #[derive(Debug, Clone)]
+// pub struct TraceOutput<H, I> {
+//     /// Inner EVM output.
+//     pub result: ExecutionResult<H>,
+//     /// Inspector state at the end of the execution.
+//     pub inspector: I,
+// }
+
+// /// Iterator used by tracer.
+// #[derive(derive_more::Debug)]
+// #[debug(bound(E::Inspector: Debug))]
+// pub struct TracerIter<'a, E: Evm, Txs: Iterator, F> {
+//     inner: &'a mut TxTracer<E>,
+//     txs: Peekable<Txs>,
+//     hook: F,
+//     skip_last_commit: bool,
+//     fuse: bool,
+// }
+
+// impl<E: Evm, Txs: Iterator, F> TracerIter<'_, E, Txs, F> {
+//     /// Flips the `skip_last_commit` flag thus making sure all transaction are committed.
+//     ///
+//     /// We are skipping last commit by default as it's expected that when tracing users are mostly
+//     /// interested in tracer output rather than in a state after it.
+//     pub fn commit_last_tx(mut self) -> Self {
+//         self.skip_last_commit = false;
+//         self
+//     }
+
+//     /// Disables inspector fusing on every transaction and expects user to fuse it manually.
+//     pub fn no_fuse(mut self) -> Self {
+//         self.fuse = false;
+//         self
+//     }
+// }
+
+// impl<E, T, Txs, F, O, Err> Iterator for TracerIter<'_, E, Txs, F>
+// where
+//     E: Evm<DB: DatabaseCommit, Inspector: Clone>,
+//     T: IntoTxEnv<E::Tx> + Clone,
+//     Txs: Iterator<Item = T>,
+//     Err: From<E::Error>,
+//     F: FnMut(TracingCtx<'_, T, E>) -> Result<O, Err>,
+// {
+//     type Item = Result<O, Err>;
+
+//     fn next(&mut self) -> Option<Self::Item> {
+//         let tx = self.txs.next()?;
+//         let result = self.inner.evm.transact(tx.clone());
+
+//         let TxTracer { evm, fused_inspector } = self.inner;
+//         let (db, inspector, _) = evm.components_mut();
+
+//         let Ok(ResultAndState { result, state }) = result else {
+//             return None;
+//         };
+//         let mut was_fused = false;
+//         let output = (self.hook)(TracingCtx {
+//             tx,
+//             result,
+//             state: &state,
+//             inspector,
+//             db,
+//             fused_inspector: &*fused_inspector,
+//             was_fused: &mut was_fused,
+//         });
+
+//         // Only commit next transaction if `skip_last_commit` is disabled or there is a next
+//         // transaction.
+//         if !self.skip_last_commit || self.txs.peek().is_some() {
+//             db.commit(state);
+//         }
+
+//         if self.fuse && !was_fused {
+//             self.inner.fuse_inspector();
+//         }
+
+//         Some(output)
+//     }
+// }
+
+
+
+
+
 //! Helpers for tracing.
 
 use crate::{Evm, IntoTxEnv};
@@ -8,16 +196,57 @@ use revm::{
     DatabaseCommit,
 };
 
+/// Trait for inspector initialization.
+pub trait InspectorInitializer<T> {
+    /// Create a new inspector instance.
+    fn initialize(&mut self) -> T;
+}
+
+/// A simple initializer that clones the inspector.
+#[derive(Debug, Clone)]
+pub struct CloneInitializer<T: Clone>(T);
+
+impl<T: Clone> CloneInitializer<T> {
+    /// Create a new clone initializer.
+    pub fn new(value: T) -> Self {
+        Self(value)
+    }
+}
+
+impl<T: Clone> InspectorInitializer<T> for CloneInitializer<T> {
+    fn initialize(&mut self) -> T {
+        self.0.clone()
+    }
+}
+
+/// An initializer that creates inspectors using a closure.
+#[derive(Debug)]
+pub struct FnInitializer<T, F: FnMut() -> T>(F);
+
+impl<T, F: FnMut() -> T> FnInitializer<T, F> {
+    /// Create a new function initializer.
+    pub fn new(f: F) -> Self {
+        Self(f)
+    }
+}
+
+impl<T, F: FnMut() -> T> InspectorInitializer<T> for FnInitializer<T, F> {
+    fn initialize(&mut self) -> T {
+        (self.0)()
+    }
+}
+
 /// A helper type for tracing transactions.
 #[derive(Debug, Clone)]
-pub struct TxTracer<E: Evm> {
+pub struct TxTracer<E: Evm, Init: InspectorInitializer<E::Inspector> = CloneInitializer<<E as Evm>::Inspector>> {
     evm: E,
     fused_inspector: E::Inspector,
+    initializer: Init,
 }
 
 /// Container type for context exposed in [`TxTracer`].
 #[derive(Debug)]
-pub struct TracingCtx<'a, T, E: Evm> {
+pub struct TracingCtx<'a, T, E: Evm, Init: InspectorInitializer<E::Inspector> = CloneInitializer<<E as Evm>::Inspector>> {
     /// The transaction that was just executed.
     pub tx: T,
     /// Result of transaction execution.
@@ -29,36 +258,50 @@ pub struct TracingCtx<'a, T, E: Evm> {
     /// Database used when executing the transaction, _before_ committing the state changes.
     pub db: &'a mut E::DB,
     /// Fused inspector.
-    fused_inspector: &'a E::Inspector,
+    pub fused_inspector: &'a E::Inspector,
     /// Whether the inspector was fused.
     was_fused: &'a mut bool,
+    /// Reference to the initializer.
+    initializer: &'a mut Init,
 }
 
-impl<'a, T, E: Evm<Inspector: Clone>> TracingCtx<'a, T, E> {
-    /// Fuses the inspector and returns the current inspector state.
-    pub fn take_inspector(&mut self) -> E::Inspector {
+impl<'a, T, E: Evm, Init: InspectorInitializer<E::Inspector>> TracingCtx<'a, T, E, Init> {
+    /// Takes the current inspector and replaces it with a fresh one.
+    /// 
+    /// This is useful when you want to keep the current inspector state but continue 
+    /// tracing with a new one.
+    pub fn take_inspector(&mut self) -> E::Inspector
+    where
+        E::Inspector: Clone,
+    {
         *self.was_fused = true;
-        core::mem::replace(self.inspector, self.fused_inspector.clone())
+        core::mem::replace(self.inspector, self.initializer.initialize())
     }
 }
 
-impl<E: Evm<Inspector: Clone, DB: DatabaseCommit>> TxTracer<E> {
-    /// Creates a new [`TxTracer`] instance.
-    pub fn new(mut evm: E) -> Self {
-        Self { fused_inspector: evm.inspector_mut().clone(), evm }
+impl<E: Evm<DB: DatabaseCommit>, Init: InspectorInitializer<E::Inspector>> TxTracer<E, Init> {
+    /// Creates a new [`TxTracer`] instance with a custom inspector initializer.
+    pub fn new_with_initializer(evm: E, mut initializer: Init) -> Self {
+        let fused_inspector = initializer.initialize();
+        Self { fused_inspector, evm, initializer }
     }
 
-    fn fuse_inspector(&mut self) -> E::Inspector {
-        core::mem::replace(self.evm.inspector_mut(), self.fused_inspector.clone())
+    /// Replaces the current inspector with a fresh one from the initializer.
+    fn reset_inspector(&mut self) -> E::Inspector {
+        let fresh = self.initializer.initialize();
+        core::mem::replace(self.evm.inspector_mut(), fresh)
     }
 
     /// Executes a transaction, and returns its outcome along with the inspector state.
     pub fn trace(
         &mut self,
         tx: impl IntoTxEnv<E::Tx>,
-    ) -> Result<TraceOutput<E::HaltReason, E::Inspector>, E::Error> {
+    ) -> Result<TraceOutput<E::HaltReason, E::Inspector>, E::Error>
+    where
+        E::Inspector: Clone,
+    {
         let result = self.evm.transact_commit(tx);
-        let inspector = self.fuse_inspector();
+        let inspector = self.reset_inspector();
         Ok(TraceOutput { result: result?, inspector })
     }
 
@@ -69,11 +312,11 @@ impl<E: Evm<Inspector: Clone, DB: DatabaseCommit>> TxTracer<E> {
         &mut self,
         txs: Txs,
         mut f: F,
-    ) -> TracerIter<'_, E, Txs::IntoIter, impl FnMut(TracingCtx<'_, T, E>) -> Result<O, E::Error>>
+    ) -> TracerIter<'_, E, Init, Txs::IntoIter, impl FnMut(TracingCtx<'_, T, E, Init>) -> Result<O, E::Error>>
     where
         T: IntoTxEnv<E::Tx> + Clone,
         Txs: IntoIterator<Item = T>,
-        F: FnMut(TracingCtx<'_, Txs::Item, E>) -> O,
+        F: FnMut(TracingCtx<'_, Txs::Item, E, Init>) -> O,
     {
         self.try_trace_many(txs, move |ctx| Ok(f(ctx)))
     }
@@ -83,11 +326,11 @@ impl<E: Evm<Inspector: Clone, DB: DatabaseCommit>> TxTracer<E> {
         &mut self,
         txs: Txs,
         hook: F,
-    ) -> TracerIter<'_, E, Txs::IntoIter, F>
+    ) -> TracerIter<'_, E, Init, Txs::IntoIter, F>
     where
         T: IntoTxEnv<E::Tx> + Clone,
         Txs: IntoIterator<Item = T>,
-        F: FnMut(TracingCtx<'_, T, E>) -> Result<O, Err>,
+        F: FnMut(TracingCtx<'_, T, E, Init>) -> Result<O, Err>,
         Err: From<E::Error>,
     {
         TracerIter {
@@ -97,6 +340,18 @@ impl<E: Evm<Inspector: Clone, DB: DatabaseCommit>> TxTracer<E> {
             skip_last_commit: true,
             fuse: true,
         }
+    }
+}
+
+// Add convenience constructor for cloneable inspectors
+impl<E: Evm<DB: DatabaseCommit>> TxTracer<E, CloneInitializer<E::Inspector>> 
+where 
+    E::Inspector: Clone,
+{
+    /// Creates a new [`TxTracer`] instance with a cloneable inspector.
+    pub fn new(mut evm: E) -> Self {
+        let inspector = evm.inspector_mut().clone();
+        Self::new_with_initializer(evm, CloneInitializer::new(inspector))
     }
 }
 
@@ -112,15 +367,15 @@ pub struct TraceOutput<H, I> {
 /// Iterator used by tracer.
 #[derive(derive_more::Debug)]
 #[debug(bound(E::Inspector: Debug))]
-pub struct TracerIter<'a, E: Evm, Txs: Iterator, F> {
-    inner: &'a mut TxTracer<E>,
+pub struct TracerIter<'a, E: Evm, Init: InspectorInitializer<E::Inspector>, Txs: Iterator, F> {
+    inner: &'a mut TxTracer<E, Init>,
     txs: Peekable<Txs>,
     hook: F,
     skip_last_commit: bool,
     fuse: bool,
 }
 
-impl<E: Evm, Txs: Iterator, F> TracerIter<'_, E, Txs, F> {
+impl<E: Evm, Init: InspectorInitializer<E::Inspector>, Txs: Iterator, F> TracerIter<'_, E, Init, Txs, F> {
     /// Flips the `skip_last_commit` flag thus making sure all transaction are committed.
     ///
     /// We are skipping last commit by default as it's expected that when tracing users are mostly
@@ -137,13 +392,14 @@ impl<E: Evm, Txs: Iterator, F> TracerIter<'_, E, Txs, F> {
     }
 }
 
-impl<E, T, Txs, F, O, Err> Iterator for TracerIter<'_, E, Txs, F>
+impl<E, Init, T, Txs, F, O, Err> Iterator for TracerIter<'_, E, Init, Txs, F>
 where
-    E: Evm<DB: DatabaseCommit, Inspector: Clone>,
+    E: Evm<DB: DatabaseCommit>,
+    Init: InspectorInitializer<E::Inspector>,
     T: IntoTxEnv<E::Tx> + Clone,
     Txs: Iterator<Item = T>,
     Err: From<E::Error>,
-    F: FnMut(TracingCtx<'_, T, E>) -> Result<O, Err>,
+    F: FnMut(TracingCtx<'_, T, E, Init>) -> Result<O, Err>,
 {
     type Item = Result<O, Err>;
 
@@ -151,7 +407,7 @@ where
         let tx = self.txs.next()?;
         let result = self.inner.evm.transact(tx.clone());
 
-        let TxTracer { evm, fused_inspector } = self.inner;
+        let TxTracer { evm, fused_inspector, initializer } = self.inner;
         let (db, inspector, _) = evm.components_mut();
 
         let Ok(ResultAndState { result, state }) = result else {
@@ -166,6 +422,7 @@ where
             db,
             fused_inspector: &*fused_inspector,
             was_fused: &mut was_fused,
+            initializer,
         });
 
         // Only commit next transaction if `skip_last_commit` is disabled or there is a next
@@ -175,7 +432,7 @@ where
         }
 
         if self.fuse && !was_fused {
-            self.inner.fuse_inspector();
+            self.inner.reset_inspector();
         }
 
         Some(output)

--- a/crates/evm/src/tracing.rs
+++ b/crates/evm/src/tracing.rs
@@ -50,7 +50,10 @@ impl<T, F: FnMut() -> T> InspectorInitializer<T> for FnInitializer<T, F> {
 
 /// A helper type for tracing transactions.
 #[derive(Debug, Clone)]
-pub struct TxTracer<E: Evm, Init: InspectorInitializer<E::Inspector> = CloneInitializer<<E as Evm>::Inspector>> {
+pub struct TxTracer<
+    E: Evm,
+    Init: InspectorInitializer<E::Inspector> = CloneInitializer<<E as Evm>::Inspector>,
+> {
     evm: E,
     fused_inspector: E::Inspector,
     initializer: Init,
@@ -58,7 +61,12 @@ pub struct TxTracer<E: Evm, Init: InspectorInitializer<E::Inspector> = CloneInit
 
 /// Container type for context exposed in [`TxTracer`].
 #[derive(Debug)]
-pub struct TracingCtx<'a, T, E: Evm, Init: InspectorInitializer<E::Inspector> = CloneInitializer<<E as Evm>::Inspector>> {
+pub struct TracingCtx<
+    'a,
+    T,
+    E: Evm,
+    Init: InspectorInitializer<E::Inspector> = CloneInitializer<<E as Evm>::Inspector>,
+> {
     /// The transaction that was just executed.
     pub tx: T,
     /// Result of transaction execution.
@@ -79,8 +87,8 @@ pub struct TracingCtx<'a, T, E: Evm, Init: InspectorInitializer<E::Inspector> = 
 
 impl<'a, T, E: Evm, Init: InspectorInitializer<E::Inspector>> TracingCtx<'a, T, E, Init> {
     /// Takes the current inspector and replaces it with a fresh one.
-    /// 
-    /// This is useful when you want to keep the current inspector state but continue 
+    ///
+    /// This is useful when you want to keep the current inspector state but continue
     /// tracing with a new one.
     pub fn take_inspector(&mut self) -> E::Inspector
     where
@@ -123,7 +131,13 @@ impl<E: Evm<DB: DatabaseCommit>, Init: InspectorInitializer<E::Inspector>> TxTra
         &mut self,
         txs: Txs,
         mut f: F,
-    ) -> TracerIter<'_, E, Init, Txs::IntoIter, impl FnMut(TracingCtx<'_, T, E, Init>) -> Result<O, E::Error>>
+    ) -> TracerIter<
+        '_,
+        E,
+        Init,
+        Txs::IntoIter,
+        impl FnMut(TracingCtx<'_, T, E, Init>) -> Result<O, E::Error>,
+    >
     where
         T: IntoTxEnv<E::Tx> + Clone,
         Txs: IntoIterator<Item = T>,
@@ -154,9 +168,8 @@ impl<E: Evm<DB: DatabaseCommit>, Init: InspectorInitializer<E::Inspector>> TxTra
     }
 }
 
-
-impl<E: Evm<DB: DatabaseCommit>> TxTracer<E, CloneInitializer<E::Inspector>> 
-where 
+impl<E: Evm<DB: DatabaseCommit>> TxTracer<E, CloneInitializer<E::Inspector>>
+where
     E::Inspector: Clone,
 {
     /// Creates a new [`TxTracer`] instance with a cloneable inspector.
@@ -186,7 +199,9 @@ pub struct TracerIter<'a, E: Evm, Init: InspectorInitializer<E::Inspector>, Txs:
     fuse: bool,
 }
 
-impl<E: Evm, Init: InspectorInitializer<E::Inspector>, Txs: Iterator, F> TracerIter<'_, E, Init, Txs, F> {
+impl<E: Evm, Init: InspectorInitializer<E::Inspector>, Txs: Iterator, F>
+    TracerIter<'_, E, Init, Txs, F>
+{
     /// Flips the `skip_last_commit` flag thus making sure all transaction are committed.
     ///
     /// We are skipping last commit by default as it's expected that when tracing users are mostly

--- a/crates/evm/src/tracing.rs
+++ b/crates/evm/src/tracing.rs
@@ -1,191 +1,3 @@
-// //! Helpers for tracing.
-
-// use crate::{Evm, IntoTxEnv};
-// use core::{fmt::Debug, iter::Peekable};
-// use revm::{
-//     context::result::{ExecutionResult, ResultAndState},
-//     state::EvmState,
-//     DatabaseCommit,
-// };
-
-// /// A helper type for tracing transactions.
-// #[derive(Debug, Clone)]
-// pub struct TxTracer<E: Evm> {
-//     evm: E,
-//     fused_inspector: E::Inspector,
-// }
-
-// /// Container type for context exposed in [`TxTracer`].
-// #[derive(Debug)]
-// pub struct TracingCtx<'a, T, E: Evm> {
-//     /// The transaction that was just executed.
-//     pub tx: T,
-//     /// Result of transaction execution.
-//     pub result: ExecutionResult<E::HaltReason>,
-//     /// State changes after transaction.
-//     pub state: &'a EvmState,
-//     /// Inspector state after transaction.
-//     pub inspector: &'a mut E::Inspector,
-//     /// Database used when executing the transaction, _before_ committing the state changes.
-//     pub db: &'a mut E::DB,
-//     /// Fused inspector.
-//     fused_inspector: &'a E::Inspector,
-//     /// Whether the inspector was fused.
-//     was_fused: &'a mut bool,
-// }
-
-// impl<'a, T, E: Evm<Inspector: Clone>> TracingCtx<'a, T, E> {
-//     /// Fuses the inspector and returns the current inspector state.
-//     pub fn take_inspector(&mut self) -> E::Inspector {
-//         *self.was_fused = true;
-//         core::mem::replace(self.inspector, self.fused_inspector.clone())
-//     }
-// }
-
-// impl<E: Evm<Inspector: Clone, DB: DatabaseCommit>> TxTracer<E> {
-//     /// Creates a new [`TxTracer`] instance.
-//     pub fn new(mut evm: E) -> Self {
-//         Self { fused_inspector: evm.inspector_mut().clone(), evm }
-//     }
-
-//     fn fuse_inspector(&mut self) -> E::Inspector {
-//         core::mem::replace(self.evm.inspector_mut(), self.fused_inspector.clone())
-//     }
-
-//     /// Executes a transaction, and returns its outcome along with the inspector state.
-//     pub fn trace(
-//         &mut self,
-//         tx: impl IntoTxEnv<E::Tx>,
-//     ) -> Result<TraceOutput<E::HaltReason, E::Inspector>, E::Error> {
-//         let result = self.evm.transact_commit(tx);
-//         let inspector = self.fuse_inspector();
-//         Ok(TraceOutput { result: result?, inspector })
-//     }
-
-//     /// Executes multiple transactions, applies the closure to each transaction result, and returns
-//     /// the outcomes.
-//     #[expect(clippy::type_complexity)]
-//     pub fn trace_many<Txs, T, F, O>(
-//         &mut self,
-//         txs: Txs,
-//         mut f: F,
-//     ) -> TracerIter<'_, E, Txs::IntoIter, impl FnMut(TracingCtx<'_, T, E>) -> Result<O, E::Error>>
-//     where
-//         T: IntoTxEnv<E::Tx> + Clone,
-//         Txs: IntoIterator<Item = T>,
-//         F: FnMut(TracingCtx<'_, Txs::Item, E>) -> O,
-//     {
-//         self.try_trace_many(txs, move |ctx| Ok(f(ctx)))
-//     }
-
-//     /// Same as [`TxTracer::trace_many`], but operates on closures returning [`Result`]s.
-//     pub fn try_trace_many<Txs, T, F, O, Err>(
-//         &mut self,
-//         txs: Txs,
-//         hook: F,
-//     ) -> TracerIter<'_, E, Txs::IntoIter, F>
-//     where
-//         T: IntoTxEnv<E::Tx> + Clone,
-//         Txs: IntoIterator<Item = T>,
-//         F: FnMut(TracingCtx<'_, T, E>) -> Result<O, Err>,
-//         Err: From<E::Error>,
-//     {
-//         TracerIter {
-//             inner: self,
-//             txs: txs.into_iter().peekable(),
-//             hook,
-//             skip_last_commit: true,
-//             fuse: true,
-//         }
-//     }
-// }
-
-// /// Output of tracing a transaction.
-// #[derive(Debug, Clone)]
-// pub struct TraceOutput<H, I> {
-//     /// Inner EVM output.
-//     pub result: ExecutionResult<H>,
-//     /// Inspector state at the end of the execution.
-//     pub inspector: I,
-// }
-
-// /// Iterator used by tracer.
-// #[derive(derive_more::Debug)]
-// #[debug(bound(E::Inspector: Debug))]
-// pub struct TracerIter<'a, E: Evm, Txs: Iterator, F> {
-//     inner: &'a mut TxTracer<E>,
-//     txs: Peekable<Txs>,
-//     hook: F,
-//     skip_last_commit: bool,
-//     fuse: bool,
-// }
-
-// impl<E: Evm, Txs: Iterator, F> TracerIter<'_, E, Txs, F> {
-//     /// Flips the `skip_last_commit` flag thus making sure all transaction are committed.
-//     ///
-//     /// We are skipping last commit by default as it's expected that when tracing users are mostly
-//     /// interested in tracer output rather than in a state after it.
-//     pub fn commit_last_tx(mut self) -> Self {
-//         self.skip_last_commit = false;
-//         self
-//     }
-
-//     /// Disables inspector fusing on every transaction and expects user to fuse it manually.
-//     pub fn no_fuse(mut self) -> Self {
-//         self.fuse = false;
-//         self
-//     }
-// }
-
-// impl<E, T, Txs, F, O, Err> Iterator for TracerIter<'_, E, Txs, F>
-// where
-//     E: Evm<DB: DatabaseCommit, Inspector: Clone>,
-//     T: IntoTxEnv<E::Tx> + Clone,
-//     Txs: Iterator<Item = T>,
-//     Err: From<E::Error>,
-//     F: FnMut(TracingCtx<'_, T, E>) -> Result<O, Err>,
-// {
-//     type Item = Result<O, Err>;
-
-//     fn next(&mut self) -> Option<Self::Item> {
-//         let tx = self.txs.next()?;
-//         let result = self.inner.evm.transact(tx.clone());
-
-//         let TxTracer { evm, fused_inspector } = self.inner;
-//         let (db, inspector, _) = evm.components_mut();
-
-//         let Ok(ResultAndState { result, state }) = result else {
-//             return None;
-//         };
-//         let mut was_fused = false;
-//         let output = (self.hook)(TracingCtx {
-//             tx,
-//             result,
-//             state: &state,
-//             inspector,
-//             db,
-//             fused_inspector: &*fused_inspector,
-//             was_fused: &mut was_fused,
-//         });
-
-//         // Only commit next transaction if `skip_last_commit` is disabled or there is a next
-//         // transaction.
-//         if !self.skip_last_commit || self.txs.peek().is_some() {
-//             db.commit(state);
-//         }
-
-//         if self.fuse && !was_fused {
-//             self.inner.fuse_inspector();
-//         }
-
-//         Some(output)
-//     }
-// }
-
-
-
-
-
 //! Helpers for tracing.
 
 use crate::{Evm, IntoTxEnv};
@@ -286,8 +98,7 @@ impl<E: Evm<DB: DatabaseCommit>, Init: InspectorInitializer<E::Inspector>> TxTra
         Self { fused_inspector, evm, initializer }
     }
 
-    /// Replaces the current inspector with a fresh one from the initializer.
-    fn reset_inspector(&mut self) -> E::Inspector {
+    fn fuse_inspector(&mut self) -> E::Inspector {
         let fresh = self.initializer.initialize();
         core::mem::replace(self.evm.inspector_mut(), fresh)
     }
@@ -301,7 +112,7 @@ impl<E: Evm<DB: DatabaseCommit>, Init: InspectorInitializer<E::Inspector>> TxTra
         E::Inspector: Clone,
     {
         let result = self.evm.transact_commit(tx);
-        let inspector = self.reset_inspector();
+        let inspector = self.fuse_inspector();
         Ok(TraceOutput { result: result?, inspector })
     }
 
@@ -343,7 +154,7 @@ impl<E: Evm<DB: DatabaseCommit>, Init: InspectorInitializer<E::Inspector>> TxTra
     }
 }
 
-// Add convenience constructor for cloneable inspectors
+
 impl<E: Evm<DB: DatabaseCommit>> TxTracer<E, CloneInitializer<E::Inspector>> 
 where 
     E::Inspector: Clone,
@@ -432,7 +243,7 @@ where
         }
 
         if self.fuse && !was_fused {
-            self.inner.reset_inspector();
+            self.inner.fuse_inspector();
         }
 
         Some(output)


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

Close #132

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Introduced an `InspectorInitializer` which can init both cloneable and non-cloneable inspectors

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
