### PR TITLE
refactor: simplify `BlockExecutorFactory` lifetimes

### DIFF
--- a/crates/evm/src/evm.rs
+++ b/crates/evm/src/evm.rs
@@ -14,8 +14,8 @@ use revm::{
 };
 
 /// Helper trait to bound [`revm::Database::Error`] with common requirements.
-pub trait Database: revm::Database<Error: Error + Send + Sync + 'static> + Debug {}
-impl<T> Database for T where T: revm::Database<Error: Error + Send + Sync + 'static> + Debug {}
+pub trait Database: revm::Database<Error: Send + Sync + 'static> + Debug {}
+impl<T> Database for T where T: revm::Database<Error: Send + Sync + 'static> + Debug {}
 
 /// An instance of an ethereum virtual machine.
 ///


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Adds `StateDB` trait that erases lifetime of `&'a mut State<DB>` and simplifies bounds on `create_executor`

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
