### PR TITLE
feat: `ToTxEnv`

### DIFF
--- a/crates/evm/src/block/mod.rs
+++ b/crates/evm/src/block/mod.rs
@@ -1,7 +1,7 @@
 //! Block execution abstraction.
 
 use crate::{
-    Database, Evm, EvmFactory, FromRecoveredTx, FromTxWithEncoded, IntoTxEnv, RecoveredTx,
+    BuildTxEnv, Database, Evm, EvmFactory, FromRecoveredTx, FromTxWithEncoded, RecoveredTx,
 };
 use alloc::{boxed::Box, vec::Vec};
 use alloy_eips::eip7685::Requests;
@@ -50,11 +50,11 @@ pub struct BlockExecutionResult<T> {
 /// The trait ensures that the block executor can both execute the transaction in the EVM
 /// and access the original transaction data for receipt generation.
 pub trait ExecutableTx<E: BlockExecutor + ?Sized>:
-    IntoTxEnv<<E::Evm as Evm>::Tx> + RecoveredTx<E::Transaction> + Copy
+    BuildTxEnv<<E::Evm as Evm>::Tx> + RecoveredTx<E::Transaction>
 {
 }
 impl<E: BlockExecutor, T> ExecutableTx<E> for T where
-    T: IntoTxEnv<<E::Evm as Evm>::Tx> + RecoveredTx<E::Transaction> + Copy
+    T: BuildTxEnv<<E::Evm as Evm>::Tx> + RecoveredTx<E::Transaction>
 {
 }
 

--- a/crates/evm/src/block/mod.rs
+++ b/crates/evm/src/block/mod.rs
@@ -1,8 +1,6 @@
 //! Block execution abstraction.
 
-use crate::{
-    BuildTxEnv, Database, Evm, EvmFactory, FromRecoveredTx, FromTxWithEncoded, RecoveredTx,
-};
+use crate::{Database, Evm, EvmFactory, FromRecoveredTx, FromTxWithEncoded, RecoveredTx, ToTxEnv};
 use alloc::{boxed::Box, vec::Vec};
 use alloy_eips::eip7685::Requests;
 use revm::{
@@ -36,7 +34,7 @@ pub struct BlockExecutionResult<T> {
 /// Helper trait to encapsulate requirements for a type to be used as input for [`BlockExecutor`].
 ///
 /// This trait combines the requirements for a transaction to be executable by a block executor:
-/// - Must be convertible to the EVM's transaction environment via [`BuildTxEnv`]
+/// - Must be convertible to the EVM's transaction environment via [`ToTxEnv`]
 /// - Must provide access to the transaction and signer via [`RecoveredTx`]
 /// - Must be [`Copy`] for efficient handling during block execution (the expectation here is that
 ///   this always passed as & reference)
@@ -50,11 +48,11 @@ pub struct BlockExecutionResult<T> {
 /// The trait ensures that the block executor can both execute the transaction in the EVM
 /// and access the original transaction data for receipt generation.
 pub trait ExecutableTx<E: BlockExecutor + ?Sized>:
-    BuildTxEnv<<E::Evm as Evm>::Tx> + RecoveredTx<E::Transaction>
+    ToTxEnv<<E::Evm as Evm>::Tx> + RecoveredTx<E::Transaction>
 {
 }
 impl<E: BlockExecutor, T> ExecutableTx<E> for T where
-    T: BuildTxEnv<<E::Evm as Evm>::Tx> + RecoveredTx<E::Transaction>
+    T: ToTxEnv<<E::Evm as Evm>::Tx> + RecoveredTx<E::Transaction>
 {
 }
 
@@ -187,7 +185,7 @@ pub trait BlockExecutor {
     /// - Custom validation logic before committing
     ///
     /// The [`ExecutableTx`] constraint ensures that:
-    /// 1. The transaction can be converted to `TxEnv` via [`BuildTxEnv`] for EVM execution
+    /// 1. The transaction can be converted to `TxEnv` via [`ToTxEnv`] for EVM execution
     /// 2. The original transaction and signer can be accessed via [`RecoveredTx`] for receipt
     ///    generation
     ///

--- a/crates/evm/src/block/mod.rs
+++ b/crates/evm/src/block/mod.rs
@@ -36,7 +36,7 @@ pub struct BlockExecutionResult<T> {
 /// Helper trait to encapsulate requirements for a type to be used as input for [`BlockExecutor`].
 ///
 /// This trait combines the requirements for a transaction to be executable by a block executor:
-/// - Must be convertible to the EVM's transaction environment via [`IntoTxEnv`]
+/// - Must be convertible to the EVM's transaction environment via [`BuildTxEnv`]
 /// - Must provide access to the transaction and signer via [`RecoveredTx`]
 /// - Must be [`Copy`] for efficient handling during block execution (the expectation here is that
 ///   this always passed as & reference)
@@ -187,7 +187,7 @@ pub trait BlockExecutor {
     /// - Custom validation logic before committing
     ///
     /// The [`ExecutableTx`] constraint ensures that:
-    /// 1. The transaction can be converted to `TxEnv` via [`IntoTxEnv`] for EVM execution
+    /// 1. The transaction can be converted to `TxEnv` via [`BuildTxEnv`] for EVM execution
     /// 2. The original transaction and signer can be accessed via [`RecoveredTx`] for receipt
     ///    generation
     ///

--- a/crates/evm/src/eth/block.rs
+++ b/crates/evm/src/eth/block.rs
@@ -125,7 +125,7 @@ where
         // Execute transaction.
         let ResultAndState { result, state } = self
             .evm
-            .transact(tx)
+            .transact(&tx)
             .map_err(|err| BlockExecutionError::evm(err, tx.tx().trie_hash()))?;
 
         if !f(&result).should_commit() {

--- a/crates/evm/src/tx.rs
+++ b/crates/evm/src/tx.rs
@@ -51,24 +51,24 @@ impl IntoTxEnv<Self> for TxEnv {
 /// A helper trait to allow implementing [`IntoTxEnv`] for types that build transaction environment
 /// by cloning data.
 #[auto_impl::auto_impl(&)]
-pub trait BuildTxEnv<TxEnv> {
+pub trait ToTxEnv<TxEnv> {
     /// Builds a [`TxEnv`] from `self`.
     fn build_tx_env(&self) -> TxEnv;
 }
 
 impl<T, TxEnv> IntoTxEnv<TxEnv> for T
 where
-    T: BuildTxEnv<TxEnv>,
+    T: ToTxEnv<TxEnv>,
 {
     fn into_tx_env(self) -> TxEnv {
         self.build_tx_env()
     }
 }
 
-impl<L, R, TxEnv> BuildTxEnv<TxEnv> for Either<L, R>
+impl<L, R, TxEnv> ToTxEnv<TxEnv> for Either<L, R>
 where
-    L: BuildTxEnv<TxEnv>,
-    R: BuildTxEnv<TxEnv>,
+    L: ToTxEnv<TxEnv>,
+    R: ToTxEnv<TxEnv>,
 {
     fn build_tx_env(&self) -> TxEnv {
         match self {
@@ -127,7 +127,7 @@ where
     }
 }
 
-impl<T, TxEnv: FromRecoveredTx<T>> BuildTxEnv<TxEnv> for Recovered<T> {
+impl<T, TxEnv: FromRecoveredTx<T>> ToTxEnv<TxEnv> for Recovered<T> {
     fn build_tx_env(&self) -> TxEnv {
         TxEnv::from_recovered_tx(self.inner(), self.signer())
     }
@@ -415,14 +415,14 @@ where
     }
 }
 
-impl<T, TxEnv: FromTxWithEncoded<T>> BuildTxEnv<TxEnv> for WithEncoded<Recovered<T>> {
+impl<T, TxEnv: FromTxWithEncoded<T>> ToTxEnv<TxEnv> for WithEncoded<Recovered<T>> {
     fn build_tx_env(&self) -> TxEnv {
         let recovered = &self.1;
         TxEnv::from_encoded_tx(recovered.inner(), recovered.signer(), self.encoded_bytes().clone())
     }
 }
 
-impl<T, TxEnv: FromTxWithEncoded<T>> BuildTxEnv<TxEnv> for WithEncoded<&Recovered<T>> {
+impl<T, TxEnv: FromTxWithEncoded<T>> ToTxEnv<TxEnv> for WithEncoded<&Recovered<T>> {
     fn build_tx_env(&self) -> TxEnv {
         TxEnv::from_encoded_tx(self.value(), *self.value().signer(), self.encoded_bytes().clone())
     }

--- a/crates/evm/src/tx.rs
+++ b/crates/evm/src/tx.rs
@@ -53,7 +53,7 @@ impl IntoTxEnv<Self> for TxEnv {
 #[auto_impl::auto_impl(&)]
 pub trait ToTxEnv<TxEnv> {
     /// Builds a [`TxEnv`] from `self`.
-    fn build_tx_env(&self) -> TxEnv;
+    fn to_tx_env(&self) -> TxEnv;
 }
 
 impl<T, TxEnv> IntoTxEnv<TxEnv> for T
@@ -61,7 +61,7 @@ where
     T: ToTxEnv<TxEnv>,
 {
     fn into_tx_env(self) -> TxEnv {
-        self.build_tx_env()
+        self.to_tx_env()
     }
 }
 
@@ -70,10 +70,10 @@ where
     L: ToTxEnv<TxEnv>,
     R: ToTxEnv<TxEnv>,
 {
-    fn build_tx_env(&self) -> TxEnv {
+    fn to_tx_env(&self) -> TxEnv {
         match self {
-            Self::Left(l) => l.build_tx_env(),
-            Self::Right(r) => r.build_tx_env(),
+            Self::Left(l) => l.to_tx_env(),
+            Self::Right(r) => r.to_tx_env(),
         }
     }
 }
@@ -128,7 +128,7 @@ where
 }
 
 impl<T, TxEnv: FromRecoveredTx<T>> ToTxEnv<TxEnv> for Recovered<T> {
-    fn build_tx_env(&self) -> TxEnv {
+    fn to_tx_env(&self) -> TxEnv {
         TxEnv::from_recovered_tx(self.inner(), self.signer())
     }
 }
@@ -416,14 +416,14 @@ where
 }
 
 impl<T, TxEnv: FromTxWithEncoded<T>> ToTxEnv<TxEnv> for WithEncoded<Recovered<T>> {
-    fn build_tx_env(&self) -> TxEnv {
+    fn to_tx_env(&self) -> TxEnv {
         let recovered = &self.1;
         TxEnv::from_encoded_tx(recovered.inner(), recovered.signer(), self.encoded_bytes().clone())
     }
 }
 
 impl<T, TxEnv: FromTxWithEncoded<T>> ToTxEnv<TxEnv> for WithEncoded<&Recovered<T>> {
-    fn build_tx_env(&self) -> TxEnv {
+    fn to_tx_env(&self) -> TxEnv {
         TxEnv::from_encoded_tx(self.value(), *self.value().signer(), self.encoded_bytes().clone())
     }
 }

--- a/crates/evm/src/tx.rs
+++ b/crates/evm/src/tx.rs
@@ -48,15 +48,32 @@ impl IntoTxEnv<Self> for TxEnv {
     }
 }
 
-impl<L, R, TxEnv> IntoTxEnv<TxEnv> for Either<L, R>
+/// A helper trait to allow implementing [`IntoTxEnv`] for types that build transaction environment
+/// by cloning data.
+#[auto_impl::auto_impl(&)]
+pub trait BuildTxEnv<TxEnv> {
+    /// Builds a [`TxEnv`] from `self`.
+    fn build_tx_env(&self) -> TxEnv;
+}
+
+impl<T, TxEnv> IntoTxEnv<TxEnv> for T
 where
-    L: IntoTxEnv<TxEnv>,
-    R: IntoTxEnv<TxEnv>,
+    T: BuildTxEnv<TxEnv>,
 {
     fn into_tx_env(self) -> TxEnv {
+        self.build_tx_env()
+    }
+}
+
+impl<L, R, TxEnv> BuildTxEnv<TxEnv> for Either<L, R>
+where
+    L: BuildTxEnv<TxEnv>,
+    R: BuildTxEnv<TxEnv>,
+{
+    fn build_tx_env(&self) -> TxEnv {
         match self {
-            Self::Left(l) => l.into_tx_env(),
-            Self::Right(r) => r.into_tx_env(),
+            Self::Left(l) => l.build_tx_env(),
+            Self::Right(r) => r.build_tx_env(),
         }
     }
 }
@@ -110,14 +127,8 @@ where
     }
 }
 
-impl<T, TxEnv: FromRecoveredTx<T>> IntoTxEnv<TxEnv> for Recovered<T> {
-    fn into_tx_env(self) -> TxEnv {
-        IntoTxEnv::into_tx_env(&self)
-    }
-}
-
-impl<T, TxEnv: FromRecoveredTx<T>> IntoTxEnv<TxEnv> for &Recovered<T> {
-    fn into_tx_env(self) -> TxEnv {
+impl<T, TxEnv: FromRecoveredTx<T>> BuildTxEnv<TxEnv> for Recovered<T> {
+    fn build_tx_env(&self) -> TxEnv {
         TxEnv::from_recovered_tx(self.inner(), self.signer())
     }
 }
@@ -404,28 +415,15 @@ where
     }
 }
 
-impl<T, TxEnv: FromTxWithEncoded<T>> IntoTxEnv<TxEnv> for WithEncoded<Recovered<T>> {
-    fn into_tx_env(self) -> TxEnv {
+impl<T, TxEnv: FromTxWithEncoded<T>> BuildTxEnv<TxEnv> for WithEncoded<Recovered<T>> {
+    fn build_tx_env(&self) -> TxEnv {
         let recovered = &self.1;
         TxEnv::from_encoded_tx(recovered.inner(), recovered.signer(), self.encoded_bytes().clone())
     }
 }
 
-impl<T, TxEnv: FromTxWithEncoded<T>> IntoTxEnv<TxEnv> for &WithEncoded<Recovered<T>> {
-    fn into_tx_env(self) -> TxEnv {
-        let recovered = &self.1;
-        TxEnv::from_encoded_tx(recovered.inner(), recovered.signer(), self.encoded_bytes().clone())
-    }
-}
-
-impl<T, TxEnv: FromTxWithEncoded<T>> IntoTxEnv<TxEnv> for WithEncoded<&Recovered<T>> {
-    fn into_tx_env(self) -> TxEnv {
-        TxEnv::from_encoded_tx(self.value(), *self.value().signer(), self.encoded_bytes().clone())
-    }
-}
-
-impl<T, TxEnv: FromTxWithEncoded<T>> IntoTxEnv<TxEnv> for &WithEncoded<&Recovered<T>> {
-    fn into_tx_env(self) -> TxEnv {
+impl<T, TxEnv: FromTxWithEncoded<T>> BuildTxEnv<TxEnv> for WithEncoded<&Recovered<T>> {
+    fn build_tx_env(&self) -> TxEnv {
         TxEnv::from_encoded_tx(self.value(), *self.value().signer(), self.encoded_bytes().clone())
     }
 }

--- a/crates/op-evm/src/block/mod.rs
+++ b/crates/op-evm/src/block/mod.rs
@@ -160,7 +160,7 @@ where
 
         // Execute transaction.
         let ResultAndState { result, state } =
-            self.evm.transact(tx).map_err(move |err| BlockExecutionError::evm(err, hash))?;
+            self.evm.transact(&tx).map_err(move |err| BlockExecutionError::evm(err, hash))?;
 
         if !f(&result).should_commit() {
             return Ok(None);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

The way we've designed and use most of the APIs is by passing transactions directly to EVM/block executors, thus using `IntoTxEnv` does not make perfect sense as it consumes `self` while we're mostly doing `&self -> TxEnv` conversions now.

## Solution

This PR introduces `BuildTxEnv` which takes `&self` and is automatically implemented for references. This allows to simplify some of the `TxEnv` implementations and drop `Copy` supertrait from `ExecutableTx`, allowing to pass owned transactions to block executors instead of just references.

The only `IntoTxEnv` implementations are now for `BuildTxEnv` and for `Self`

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
