### PR TITLE
feat: add inspect_system_call method to Evm trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,6 @@ serde = { version = "1", default-features = false, features = ["derive"] }
 thiserror = { version = "2.0.0", default-features = false }
 serde_json = "1"
 
-#[patch.crates-io]
-#revm = { git = "https://github.com/bluealloy/revm", rev = "11b16259" }
-#op-revm = { git = "https://github.com/bluealloy/revm", rev = "11b16259" }
+[patch.crates-io]
+revm = { git = "https://github.com/bluealloy/revm", rev = "9008e93" }
+op-revm = { git = "https://github.com/bluealloy/revm", rev = "9008e93" }

--- a/crates/evm/src/either.rs
+++ b/crates/evm/src/either.rs
@@ -45,6 +45,15 @@ where
         either::for_both!(self, evm => evm.transact(tx))
     }
 
+    fn inspect_system_call(
+        &mut self,
+        caller: Address,
+        contract: Address,
+        data: Bytes,
+    ) -> Result<revm::context::result::ResultAndState<Self::HaltReason>, Self::Error> {
+        either::for_both!(self, evm => evm.inspect_system_call(caller, contract, data))
+    }
+
     fn transact_system_call(
         &mut self,
         caller: Address,

--- a/crates/evm/src/eth/mod.rs
+++ b/crates/evm/src/eth/mod.rs
@@ -14,7 +14,8 @@ use revm::{
     interpreter::{interpreter::EthInterpreter, InterpreterResult},
     precompile::{PrecompileSpecId, Precompiles},
     primitives::hardfork::SpecId,
-    Context, ExecuteEvm, InspectEvm, Inspector, MainBuilder, MainContext, SystemCallEvm,
+    Context, ExecuteEvm, InspectEvm, InspectSystemCallEvm, Inspector, MainBuilder, MainContext,
+    SystemCallEvm,
 };
 
 mod block;
@@ -136,13 +137,22 @@ where
         }
     }
 
+    fn inspect_system_call(
+        &mut self,
+        caller: Address,
+        contract: Address,
+        data: Bytes,
+    ) -> Result<ResultAndState<Self::HaltReason>, Self::Error> {
+        self.inner.inspect_system_call_with_caller(caller, contract, data)
+    }
+
     fn transact_system_call(
         &mut self,
         caller: Address,
         contract: Address,
         data: Bytes,
     ) -> Result<ResultAndState<Self::HaltReason>, Self::Error> {
-        self.inner.transact_system_call_with_caller_finalize(caller, contract, data)
+        self.inner.system_call_with_caller(caller, contract, data)
     }
 
     fn finish(self) -> (Self::DB, EvmEnv<Self::Spec>) {

--- a/crates/evm/src/evm.rs
+++ b/crates/evm/src/evm.rs
@@ -88,6 +88,18 @@ pub trait Evm {
         self.transact_raw(tx.into_tx_env())
     }
 
+    /// Inspects a system call without committing state changes.
+    ///
+    /// This method executes a system call with inspection enabled, allowing observation of the
+    /// execution without modifying the underlying state. Similar to [`Evm::transact_system_call`]
+    /// but returns the result with state changes that can be examined or discarded.
+    fn inspect_system_call(
+        &mut self,
+        caller: Address,
+        contract: Address,
+        data: Bytes,
+    ) -> Result<ResultAndState<Self::HaltReason>, Self::Error>;
+
     /// Executes a system call.
     ///
     /// Note: this will only keep the target `contract` in the state. This is done because revm is

--- a/crates/op-evm/src/lib.rs
+++ b/crates/op-evm/src/lib.rs
@@ -25,7 +25,7 @@ use revm::{
     handler::{instructions::EthInstructions, PrecompileProvider},
     inspector::NoOpInspector,
     interpreter::{interpreter::EthInterpreter, InterpreterResult},
-    Context, ExecuteEvm, InspectEvm, Inspector, SystemCallEvm,
+    Context, ExecuteEvm, InspectEvm, InspectSystemCallEvm, Inspector, SystemCallEvm,
 };
 
 pub mod block;
@@ -116,13 +116,22 @@ where
         }
     }
 
+    fn inspect_system_call(
+        &mut self,
+        caller: Address,
+        contract: Address,
+        data: Bytes,
+    ) -> Result<ResultAndState<Self::HaltReason>, Self::Error> {
+        self.inner.inspect_system_call_with_caller(caller, contract, data)
+    }
+
     fn transact_system_call(
         &mut self,
         caller: Address,
         contract: Address,
         data: Bytes,
     ) -> Result<ResultAndState<Self::HaltReason>, Self::Error> {
-        self.inner.transact_system_call_with_caller_finalize(caller, contract, data)
+        self.inner.system_call_with_caller(caller, contract, data)
     }
 
     fn finish(self) -> (Self::DB, EvmEnv<Self::Spec>) {


### PR DESCRIPTION
Adds a dedicated inspect_system_call method that executes system calls with inspection enabled without committing state changes. This separates the concerns of inspection and transaction execution for system calls.

- Add inspect_system_call to Evm trait with documentation
- Implement across all EVM types (Either, EthEvm, OpEvm)
- Refactor transact_system_call to always use non-inspecting variant
- Add required ResultAndState import to either.rs

Update Cargo.toml

Update either.rs

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
