### PR TITLE
chore: update `EvmInternals::new()` to pub

### DIFF
--- a/crates/evm/src/traits.rs
+++ b/crates/evm/src/traits.rs
@@ -162,7 +162,7 @@ pub struct EvmInternals<'a> {
 
 impl<'a> EvmInternals<'a> {
     /// Creates a new [`EvmInternals`] instance.
-    pub(crate) fn new<T>(journal: &'a mut T, block_env: &'a dyn Block) -> Self
+    pub fn new<T>(journal: &'a mut T, block_env: &'a dyn Block) -> Self
     where
         T: JournalTr<Database: Database> + Debug,
     {


### PR DESCRIPTION
This change updates the visibility of `EvmInternals::new()` from private to `pub`, allowing it to be directly accessed by external crates and libraries.

Previously, `EvmInternals::new()` could only be used internally, which limited flexibility when developing/testing external crates that use `EvmInternals`. Making it public removes the need for workarounds or additional helper functions.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
