### PR TITLE
feat: add State generic to Evm trait

### DIFF
--- a/crates/evm/src/block/system_calls/eip2935.rs
+++ b/crates/evm/src/block/system_calls/eip2935.rs
@@ -8,7 +8,7 @@ use alloc::string::ToString;
 use alloy_eips::eip2935::HISTORY_STORAGE_ADDRESS;
 use alloy_hardforks::EthereumHardforks;
 use alloy_primitives::B256;
-use revm::context_interface::result::ResultAndState;
+use revm::{context_interface::result::ResultAndState, state::EvmState};
 
 /// Applies the pre-block call to the [EIP-2935] blockhashes contract, using the given block,
 /// chain specification, and EVM.
@@ -23,11 +23,11 @@ use revm::context_interface::result::ResultAndState;
 ///
 /// [EIP-2935]: https://eips.ethereum.org/EIPS/eip-2935
 #[inline]
-pub(crate) fn transact_blockhashes_contract_call<Halt>(
+pub(crate) fn transact_blockhashes_contract_call<Halt, State: Into<EvmState>>(
     spec: impl EthereumHardforks,
     parent_block_hash: B256,
-    evm: &mut impl Evm<HaltReason = Halt>,
-) -> Result<Option<ResultAndState<Halt>>, BlockExecutionError> {
+    evm: &mut impl Evm<HaltReason = Halt, State = State>,
+) -> Result<Option<ResultAndState<Halt, State>>, BlockExecutionError> {
     if !spec.is_prague_active_at_timestamp(evm.block().timestamp.saturating_to()) {
         return Ok(None);
     }

--- a/crates/evm/src/block/system_calls/eip4788.rs
+++ b/crates/evm/src/block/system_calls/eip4788.rs
@@ -8,7 +8,7 @@ use alloc::{boxed::Box, string::ToString};
 use alloy_eips::eip4788::BEACON_ROOTS_ADDRESS;
 use alloy_hardforks::EthereumHardforks;
 use alloy_primitives::B256;
-use revm::context_interface::result::ResultAndState;
+use revm::{context_interface::result::ResultAndState, state::EvmState};
 
 /// Applies the pre-block call to the [EIP-4788] beacon block root contract, using the given block,
 /// chain spec, EVM.
@@ -20,11 +20,11 @@ use revm::context_interface::result::ResultAndState;
 ///
 /// [EIP-4788]: https://eips.ethereum.org/EIPS/eip-4788
 #[inline]
-pub(crate) fn transact_beacon_root_contract_call<Halt>(
+pub(crate) fn transact_beacon_root_contract_call<Halt, State: Into<EvmState>>(
     spec: impl EthereumHardforks,
     parent_beacon_block_root: Option<B256>,
-    evm: &mut impl Evm<HaltReason = Halt>,
-) -> Result<Option<ResultAndState<Halt>>, BlockExecutionError> {
+    evm: &mut impl Evm<HaltReason = Halt, State = State>,
+) -> Result<Option<ResultAndState<Halt, State>>, BlockExecutionError> {
     if !spec.is_cancun_active_at_timestamp(evm.block().timestamp.saturating_to()) {
         return Ok(None);
     }

--- a/crates/evm/src/block/system_calls/eip7002.rs
+++ b/crates/evm/src/block/system_calls/eip7002.rs
@@ -8,7 +8,10 @@ use alloc::format;
 use alloy_eips::eip7002::WITHDRAWAL_REQUEST_PREDEPLOY_ADDRESS;
 use alloy_primitives::Bytes;
 use core::fmt::Debug;
-use revm::context_interface::result::{ExecutionResult, ResultAndState};
+use revm::{
+    context_interface::result::{ExecutionResult, ResultAndState},
+    state::EvmState,
+};
 
 /// Applies the post-block call to the EIP-7002 withdrawal requests contract.
 ///
@@ -16,9 +19,9 @@ use revm::context_interface::result::{ExecutionResult, ResultAndState};
 ///
 /// Note: this does not commit the state changes to the database, it only transact the call.
 #[inline]
-pub(crate) fn transact_withdrawal_requests_contract_call<Halt>(
-    evm: &mut impl Evm<HaltReason = Halt>,
-) -> Result<ResultAndState<Halt>, BlockExecutionError> {
+pub(crate) fn transact_withdrawal_requests_contract_call<Halt, State: Into<EvmState>>(
+    evm: &mut impl Evm<HaltReason = Halt, State = State>,
+) -> Result<ResultAndState<Halt, State>, BlockExecutionError> {
     // Execute EIP-7002 withdrawal requests contract message data.
     //
     // This requirement for the withdrawal requests contract call defined by

--- a/crates/evm/src/block/system_calls/eip7251.rs
+++ b/crates/evm/src/block/system_calls/eip7251.rs
@@ -8,7 +8,10 @@ use alloc::format;
 use alloy_eips::eip7251::CONSOLIDATION_REQUEST_PREDEPLOY_ADDRESS;
 use alloy_primitives::Bytes;
 use core::fmt::Debug;
-use revm::context_interface::result::{ExecutionResult, ResultAndState};
+use revm::{
+    context_interface::result::{ExecutionResult, ResultAndState},
+    state::EvmState,
+};
 
 /// Applies the post-block call to the EIP-7251 consolidation requests contract.
 ///
@@ -17,9 +20,9 @@ use revm::context_interface::result::{ExecutionResult, ResultAndState};
 ///
 /// Note: this does not commit the state changes to the database, it only transact the call.
 #[inline]
-pub(crate) fn transact_consolidation_requests_contract_call<Halt>(
-    evm: &mut impl Evm<HaltReason = Halt>,
-) -> Result<ResultAndState<Halt>, BlockExecutionError> {
+pub(crate) fn transact_consolidation_requests_contract_call<Halt, State: Into<EvmState>>(
+    evm: &mut impl Evm<HaltReason = Halt, State = State>,
+) -> Result<ResultAndState<Halt, State>, BlockExecutionError> {
     // Execute EIP-7251 consolidation requests contract message data.
     //
     // This requirement for the consolidation requests contract call defined by

--- a/crates/evm/src/block/system_calls/mod.rs
+++ b/crates/evm/src/block/system_calls/mod.rs
@@ -93,13 +93,14 @@ where
             eip2935::transact_blockhashes_contract_call(&self.spec, parent_block_hash, evm)?;
 
         if let Some(res) = result_and_state {
+            let evm_state = res.state.into();
             if let Some(hook) = &mut self.hook {
                 hook.on_state(
                     StateChangeSource::PreBlock(StateChangePreBlockSource::BlockHashesContract),
-                    &res.state,
+                    &evm_state,
                 );
             }
-            evm.db_mut().commit(res.state);
+            evm.db_mut().commit(evm_state);
         }
 
         Ok(())
@@ -115,13 +116,14 @@ where
             eip4788::transact_beacon_root_contract_call(&self.spec, parent_beacon_block_root, evm)?;
 
         if let Some(res) = result_and_state {
+            let evm_state = res.state.into();
             if let Some(hook) = &mut self.hook {
                 hook.on_state(
                     StateChangeSource::PreBlock(StateChangePreBlockSource::BeaconRootContract),
-                    &res.state,
+                    &evm_state,
                 );
             }
-            evm.db_mut().commit(res.state);
+            evm.db_mut().commit(evm_state);
         }
 
         Ok(())
@@ -134,15 +136,16 @@ where
     ) -> Result<Bytes, BlockExecutionError> {
         let result_and_state = eip7002::transact_withdrawal_requests_contract_call(evm)?;
 
+        let evm_state = result_and_state.state.into();
         if let Some(ref mut hook) = &mut self.hook {
             hook.on_state(
                 StateChangeSource::PostBlock(
                     StateChangePostBlockSource::WithdrawalRequestsContract,
                 ),
-                &result_and_state.state,
+                &evm_state,
             );
         }
-        evm.db_mut().commit(result_and_state.state);
+        evm.db_mut().commit(evm_state);
 
         eip7002::post_commit(result_and_state.result)
     }
@@ -154,15 +157,16 @@ where
     ) -> Result<Bytes, BlockExecutionError> {
         let result_and_state = eip7251::transact_consolidation_requests_contract_call(evm)?;
 
+        let evm_state = result_and_state.state.into();
         if let Some(ref mut hook) = &mut self.hook {
             hook.on_state(
                 StateChangeSource::PostBlock(
                     StateChangePostBlockSource::ConsolidationRequestsContract,
                 ),
-                &result_and_state.state,
+                &evm_state,
             );
         }
-        evm.db_mut().commit(result_and_state.state);
+        evm.db_mut().commit(evm_state);
 
         eip7251::post_commit(result_and_state.result)
     }

--- a/crates/evm/src/either.rs
+++ b/crates/evm/src/either.rs
@@ -13,6 +13,7 @@ where
         Spec = L::Spec,
         Precompiles = L::Precompiles,
         Inspector = L::Inspector,
+        State = L::State,
     >,
 {
     type DB = L::DB;
@@ -22,6 +23,7 @@ where
     type Spec = L::Spec;
     type Precompiles = L::Precompiles;
     type Inspector = L::Inspector;
+    type State = L::State;
 
     fn block(&self) -> &BlockEnv {
         either::for_both!(self, evm => evm.block())
@@ -34,14 +36,16 @@ where
     fn transact_raw(
         &mut self,
         tx: Self::Tx,
-    ) -> Result<revm::context::result::ResultAndState<Self::HaltReason>, Self::Error> {
+    ) -> Result<revm::context::result::ResultAndState<Self::HaltReason, Self::State>, Self::Error>
+    {
         either::for_both!(self, evm => evm.transact_raw(tx))
     }
 
     fn transact(
         &mut self,
         tx: impl crate::IntoTxEnv<Self::Tx>,
-    ) -> Result<revm::context::result::ResultAndState<Self::HaltReason>, Self::Error> {
+    ) -> Result<revm::context::result::ResultAndState<Self::HaltReason, Self::State>, Self::Error>
+    {
         either::for_both!(self, evm => evm.transact(tx))
     }
 
@@ -50,7 +54,8 @@ where
         caller: Address,
         contract: Address,
         data: Bytes,
-    ) -> Result<revm::context::result::ResultAndState<Self::HaltReason>, Self::Error> {
+    ) -> Result<revm::context::result::ResultAndState<Self::HaltReason, Self::State>, Self::Error>
+    {
         either::for_both!(self, evm => evm.transact_system_call(caller, contract, data))
     }
 

--- a/crates/evm/src/eth/block.rs
+++ b/crates/evm/src/eth/block.rs
@@ -132,7 +132,10 @@ where
             return Ok(None);
         }
 
-        self.system_caller.on_state(StateChangeSource::Transaction(self.receipts.len()), &state);
+        let evm_state = state.into();
+
+        self.system_caller
+            .on_state(StateChangeSource::Transaction(self.receipts.len()), &evm_state);
 
         let gas_used = result.gas_used();
 
@@ -144,12 +147,12 @@ where
             tx: tx.tx(),
             evm: &self.evm,
             result,
-            state: &state,
+            state: &evm_state,
             cumulative_gas_used: self.gas_used,
         }));
 
         // Commit the state changes.
-        self.evm.db_mut().commit(state);
+        self.evm.db_mut().commit(evm_state);
 
         Ok(Some(gas_used))
     }

--- a/crates/evm/src/eth/mod.rs
+++ b/crates/evm/src/eth/mod.rs
@@ -14,6 +14,7 @@ use revm::{
     interpreter::{interpreter::EthInterpreter, InterpreterResult},
     precompile::{PrecompileSpecId, Precompiles},
     primitives::hardfork::SpecId,
+    state::EvmState,
     Context, ExecuteEvm, InspectEvm, Inspector, MainBuilder, MainContext, SystemCallEvm,
 };
 
@@ -200,6 +201,7 @@ where
     type Spec = SpecId;
     type Precompiles = PRECOMPILE;
     type Inspector = I;
+    type State = EvmState;
 
     fn block(&self) -> &BlockEnv {
         &self.block

--- a/crates/evm/src/tracing.rs
+++ b/crates/evm/src/tracing.rs
@@ -158,10 +158,11 @@ where
             return None;
         };
         let mut was_fused = false;
+        let evm_state = state.into();
         let output = (self.hook)(TracingCtx {
             tx,
             result,
-            state: &state,
+            state: &evm_state,
             inspector,
             db,
             fused_inspector: &*fused_inspector,
@@ -171,7 +172,7 @@ where
         // Only commit next transaction if `skip_last_commit` is disabled or there is a next
         // transaction.
         if !self.skip_last_commit || self.txs.peek().is_some() {
-            db.commit(state);
+            db.commit(evm_state);
         }
 
         if self.fuse && !was_fused {

--- a/crates/op-evm/src/block/mod.rs
+++ b/crates/op-evm/src/block/mod.rs
@@ -166,7 +166,9 @@ where
             return Ok(None);
         }
 
-        self.system_caller.on_state(StateChangeSource::Transaction(self.receipts.len()), &state);
+        let evm_state = state.into();
+        self.system_caller
+            .on_state(StateChangeSource::Transaction(self.receipts.len()), &evm_state);
 
         let gas_used = result.gas_used();
 
@@ -179,7 +181,7 @@ where
                 result,
                 cumulative_gas_used: self.gas_used,
                 evm: &self.evm,
-                state: &state,
+                state: &evm_state,
             }) {
                 Ok(receipt) => receipt,
                 Err(ctx) => {
@@ -209,7 +211,7 @@ where
             },
         );
 
-        self.evm.db_mut().commit(state);
+        self.evm.db_mut().commit(evm_state);
 
         Ok(Some(gas_used))
     }

--- a/crates/op-evm/src/lib.rs
+++ b/crates/op-evm/src/lib.rs
@@ -25,6 +25,7 @@ use revm::{
     handler::{instructions::EthInstructions, PrecompileProvider},
     inspector::NoOpInspector,
     interpreter::{interpreter::EthInterpreter, InterpreterResult},
+    state::EvmState,
     Context, ExecuteEvm, InspectEvm, Inspector, SystemCallEvm,
 };
 
@@ -96,6 +97,7 @@ where
     type Spec = OpSpecId;
     type Precompiles = P;
     type Inspector = I;
+    type State = EvmState;
 
     fn block(&self) -> &BlockEnv {
         &self.block


### PR DESCRIPTION
### Problem

- as of now the `Evm` trait hard codes the `ResultAndState<Self::HaltReason>` without providing the possibility to use a custom state, different than the evm state.
- The `ResultAndState` though has the possibility to use a generic `S` (it defaults to `EvmState`).
- This way it's not possible to use a custom state in the evm.

### Solution

- add a new associated type `State: Into<EvmState>` and use it in the `ResultAndState` type: `ResultAndState<Self::HaltReason, Self::State>`.
- we still need the `State` associated type to be convertible into a `EvmState` now, but at least we let implementers of the `Evm` trait to use a custom state that wraps the `EvmState` with something more.

What do you think? @mattsse 