### PR TITLE
chore: `missing-const-for-fn` lint back to "warn".

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ unnameable-types = "warn"
 
 [workspace.lints.clippy]
 all = { level = "warn", priority = -1 }
-missing-const-for-fn = "allow" # TODO: https://github.com/rust-lang/rust-clippy/issues/14020
+missing-const-for-fn = "warn"
 use-self = "warn"
 option-if-let-else = "warn"
 redundant-clone = "warn"

--- a/crates/evm/src/block/mod.rs
+++ b/crates/evm/src/block/mod.rs
@@ -68,7 +68,7 @@ pub enum CommitChanges {
 
 impl CommitChanges {
     /// Returns `true` if transaction should be committed into block executor's state.
-    pub fn should_commit(self) -> bool {
+    pub const fn should_commit(self) -> bool {
         matches!(self, Self::Yes)
     }
 }

--- a/crates/evm/src/env.rs
+++ b/crates/evm/src/env.rs
@@ -47,7 +47,7 @@ impl<Spec> EvmEnv<Spec> {
     }
 
     /// Overrides the configured block number
-    pub fn with_block_number(mut self, number: U256) -> Self {
+    pub const fn with_block_number(mut self, number: U256) -> Self {
         self.block_env.number = number;
         self
     }
@@ -56,7 +56,7 @@ impl<Spec> EvmEnv<Spec> {
     /// `Some(number)`.
     ///
     /// This is intended for block overrides.
-    pub fn with_block_number_opt(mut self, number: Option<U256>) -> Self {
+    pub const fn with_block_number_opt(mut self, number: Option<U256>) -> Self {
         if let Some(number) = number {
             self.block_env.number = number;
         }
@@ -64,7 +64,7 @@ impl<Spec> EvmEnv<Spec> {
     }
 
     /// Sets the block number if provided.
-    pub fn set_block_number_opt(&mut self, number: Option<U256>) -> &mut Self {
+    pub const fn set_block_number_opt(&mut self, number: Option<U256>) -> &mut Self {
         if let Some(number) = number {
             self.block_env.number = number;
         }
@@ -72,7 +72,7 @@ impl<Spec> EvmEnv<Spec> {
     }
 
     /// Overrides the configured block timestamp.
-    pub fn with_timestamp(mut self, timestamp: U256) -> Self {
+    pub const fn with_timestamp(mut self, timestamp: U256) -> Self {
         self.block_env.timestamp = timestamp;
         self
     }
@@ -81,7 +81,7 @@ impl<Spec> EvmEnv<Spec> {
     /// `Some(timestamp)`.
     ///
     /// This is intended for block overrides.
-    pub fn with_timestamp_opt(mut self, timestamp: Option<U256>) -> Self {
+    pub const fn with_timestamp_opt(mut self, timestamp: Option<U256>) -> Self {
         if let Some(timestamp) = timestamp {
             self.block_env.timestamp = timestamp;
         }
@@ -89,7 +89,7 @@ impl<Spec> EvmEnv<Spec> {
     }
 
     /// Sets the block timestamp if provided.
-    pub fn set_timestamp_opt(&mut self, timestamp: Option<U256>) -> &mut Self {
+    pub const fn set_timestamp_opt(&mut self, timestamp: Option<U256>) -> &mut Self {
         if let Some(timestamp) = timestamp {
             self.block_env.timestamp = timestamp;
         }
@@ -97,7 +97,7 @@ impl<Spec> EvmEnv<Spec> {
     }
 
     /// Overrides the configured block base fee.
-    pub fn with_base_fee(mut self, base_fee: u64) -> Self {
+    pub const fn with_base_fee(mut self, base_fee: u64) -> Self {
         self.block_env.basefee = base_fee;
         self
     }
@@ -106,7 +106,7 @@ impl<Spec> EvmEnv<Spec> {
     /// `Some(base_fee)`.
     ///
     /// This is intended for block overrides.
-    pub fn with_base_fee_opt(mut self, base_fee: Option<u64>) -> Self {
+    pub const fn with_base_fee_opt(mut self, base_fee: Option<u64>) -> Self {
         if let Some(base_fee) = base_fee {
             self.block_env.basefee = base_fee;
         }
@@ -114,7 +114,7 @@ impl<Spec> EvmEnv<Spec> {
     }
 
     /// Sets the block base fee if provided.
-    pub fn set_base_fee_opt(&mut self, base_fee: Option<u64>) -> &mut Self {
+    pub const fn set_base_fee_opt(&mut self, base_fee: Option<u64>) -> &mut Self {
         if let Some(base_fee) = base_fee {
             self.block_env.basefee = base_fee;
         }

--- a/crates/evm/src/eth/mod.rs
+++ b/crates/evm/src/eth/mod.rs
@@ -41,7 +41,7 @@ pub struct EthEvmBuilder<DB: Database, I = NoOpInspector> {
 
 impl<DB: Database> EthEvmBuilder<DB, NoOpInspector> {
     /// Creates a builder from the provided `EvmEnv` and database.
-    pub fn new(db: DB, env: EvmEnv) -> Self {
+    pub const fn new(db: DB, env: EvmEnv) -> Self {
         Self {
             db,
             block_env: env.block_env,
@@ -72,13 +72,13 @@ impl<DB: Database, I> EthEvmBuilder<DB, I> {
     }
 
     /// Sets whether to invoke the inspector during transaction execution.
-    pub fn set_inspect(mut self, inspect: bool) -> Self {
+    pub const fn set_inspect(mut self, inspect: bool) -> Self {
         self.inspect = inspect;
         self
     }
 
     /// Enables invoking the inspector during transaction execution.
-    pub fn inspect(self) -> Self {
+    pub const fn inspect(self) -> Self {
         self.set_inspect(true)
     }
 
@@ -166,7 +166,7 @@ impl<DB: Database, I, PRECOMPILE> EthEvm<DB, I, PRECOMPILE> {
     }
 
     /// Provides a mutable reference to the EVM context.
-    pub fn ctx_mut(&mut self) -> &mut EthEvmContext<DB> {
+    pub const fn ctx_mut(&mut self) -> &mut EthEvmContext<DB> {
         &mut self.inner.ctx
     }
 }

--- a/crates/evm/src/precompiles.rs
+++ b/crates/evm/src/precompiles.rs
@@ -535,32 +535,32 @@ pub struct PrecompileInput<'a> {
 
 impl<'a> PrecompileInput<'a> {
     /// Returns the calldata of the call.
-    pub fn data(&self) -> &[u8] {
+    pub const fn data(&self) -> &[u8] {
         self.data
     }
 
     /// Returns the caller address of the call.
-    pub fn caller(&self) -> &Address {
+    pub const fn caller(&self) -> &Address {
         &self.caller
     }
 
     /// Returns the gas limit of the call.
-    pub fn gas(&self) -> u64 {
+    pub const fn gas(&self) -> u64 {
         self.gas
     }
 
     /// Returns the value of the call.
-    pub fn value(&self) -> &U256 {
+    pub const fn value(&self) -> &U256 {
         &self.value
     }
 
     /// Returns the target address of the call.
-    pub fn target_address(&self) -> &Address {
+    pub const fn target_address(&self) -> &Address {
         &self.target_address
     }
 
     /// Returns the bytecode address of the call.
-    pub fn bytecode_address(&self) -> &Address {
+    pub const fn bytecode_address(&self) -> &Address {
         &self.bytecode_address
     }
 
@@ -571,12 +571,12 @@ impl<'a> PrecompileInput<'a> {
     }
 
     /// Returns the [`EvmInternals`].
-    pub fn internals(&self) -> &EvmInternals<'_> {
+    pub const fn internals(&self) -> &EvmInternals<'_> {
         &self.internals
     }
 
     /// Returns a mutable reference to the [`EvmInternals`].
-    pub fn internals_mut(&mut self) -> &mut EvmInternals<'a> {
+    pub const fn internals_mut(&mut self) -> &mut EvmInternals<'a> {
         &mut self.internals
     }
 }

--- a/crates/evm/src/tracing.rs
+++ b/crates/evm/src/tracing.rs
@@ -125,13 +125,13 @@ impl<E: Evm, Txs: Iterator, F> TracerIter<'_, E, Txs, F> {
     ///
     /// We are skipping last commit by default as it's expected that when tracing users are mostly
     /// interested in tracer output rather than in a state after it.
-    pub fn commit_last_tx(mut self) -> Self {
+    pub const fn commit_last_tx(mut self) -> Self {
         self.skip_last_commit = false;
         self
     }
 
     /// Disables inspector fusing on every transaction and expects user to fuse it manually.
-    pub fn no_fuse(mut self) -> Self {
+    pub const fn no_fuse(mut self) -> Self {
         self.fuse = false;
         self
     }

--- a/crates/op-evm/src/lib.rs
+++ b/crates/op-evm/src/lib.rs
@@ -49,7 +49,7 @@ impl<DB: Database, I, P> OpEvm<DB, I, P> {
     }
 
     /// Provides a mutable reference to the EVM context.
-    pub fn ctx_mut(&mut self) -> &mut OpContext<DB> {
+    pub const fn ctx_mut(&mut self) -> &mut OpContext<DB> {
         &mut self.inner.0.ctx
     }
 }


### PR DESCRIPTION
## Motivation
Close #166

## Solution

Updated multiple functions to use `const fn` to comply with the updated lint level.


## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
