### PR TITLE
chore: fix script execution and simplify CI logging

### DIFF
--- a/scripts/check_no_std.sh
+++ b/scripts/check_no_std.sh
@@ -7,16 +7,13 @@ no_std_packages=(
 )
 
 for package in "${no_std_packages[@]}"; do
-  cmd="cargo +stable build -p $package --target riscv32imac-unknown-none-elf --no-default-features"
   if [ -n "$CI" ]; then
-    echo "::group::$cmd"
+    echo "::group::cargo +stable build -p $package --target riscv32imac-unknown-none-elf --no-default-features"
   else
-    printf "\n%s:\n  %s\n" "$package" "$cmd"
+    printf "\n%s:\n  %s\n" "$package" "cargo +stable build -p $package --target riscv32imac-unknown-none-elf --no-default-features"
   fi
 
-  $cmd
+  cargo +stable build -p "$package" --target riscv32imac-unknown-none-elf --no-default-features
 
-  if [ -n "$CI" ]; then
-    echo "::endgroup::"
-  fi
+  [ -n "$CI" ] && echo "::endgroup::"
 done


### PR DESCRIPTION
## Motivation

script had some unnecessary complexity and potential issues with argument handling.
making it simpler and safer improves maintainability and avoids unexpected behavior with different `$package` values.

## Solution

* removed the `cmd` variable - now commands are invoked directly.
* arguments are passed via `...`, safely supporting any `$package`.
* logs stay readable through a single command string without arrays.
* simplified the `if` for `::endgroup::` using `[ -n "$CI" ] && ...`.

this keeps all original functionality while making the script cleaner and easier to understand.

## PR Checklist

* [ ] Added Tests
* [ ] Added Documentation
* [ ] Breaking changes
