### PR TITLE
feat: add `BlockValidationError::Other`

### DIFF
--- a/crates/evm/src/block/error.rs
+++ b/crates/evm/src/block/error.rs
@@ -79,6 +79,24 @@ pub enum BlockValidationError {
     /// [EIP-6110]: https://eips.ethereum.org/EIPS/eip-6110
     #[error("failed to decode deposit requests from receipts: {_0}")]
     DepositRequestDecode(String),
+    /// Arbitrary Block validation errors.
+    #[error(transparent)]
+    Other(Box<dyn core::error::Error + Send + Sync + 'static>),
+}
+
+impl BlockValidationError {
+    /// Create a new [`BlockValidationError::Other`] variant.
+    pub fn other<E>(error: E) -> Self
+    where
+        E: core::error::Error + Send + Sync + 'static,
+    {
+        Self::Other(Box::new(error))
+    }
+
+    /// Create a new [`BlockValidationError::Other`] variant from a given message.
+    pub fn msg(msg: impl core::fmt::Display) -> Self {
+        Self::Other(msg.to_string().into())
+    }
 }
 
 /// `BlockExecutor` Errors


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Right now arbitrary error messages can only be converted into `BlockExecutionError::Internal` variant which is not perfect as it causes reth engine to treat errors as internal ones vs caused by invalid block.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
