### PR TITLE
chore: make OpBlockExecutor fields pub

### DIFF
--- a/crates/op-evm/src/block/mod.rs
+++ b/crates/op-evm/src/block/mod.rs
@@ -41,22 +41,21 @@ pub struct OpBlockExecutionCtx {
 #[derive(Debug)]
 pub struct OpBlockExecutor<Evm, R: OpReceiptBuilder, Spec> {
     /// Spec.
-    spec: Spec,
+    pub spec: Spec,
     /// Receipt builder.
-    receipt_builder: R,
-
+    pub receipt_builder: R,
     /// Context for block execution.
-    ctx: OpBlockExecutionCtx,
+    pub ctx: OpBlockExecutionCtx,
     /// The EVM used by executor.
-    evm: Evm,
+    pub evm: Evm,
     /// Receipts of executed transactions.
-    receipts: Vec<R::Receipt>,
+    pub receipts: Vec<R::Receipt>,
     /// Total gas used by executed transactions.
-    gas_used: u64,
+    pub gas_used: u64,
     /// Whether Regolith hardfork is active.
-    is_regolith: bool,
+    pub is_regolith: bool,
     /// Utility to call system smart contracts.
-    system_caller: SystemCaller<Spec>,
+    pub system_caller: SystemCaller<Spec>,
 }
 
 impl<E, R, Spec> OpBlockExecutor<E, R, Spec>
@@ -265,11 +264,11 @@ pub struct OpBlockExecutorFactory<
     EvmFactory = OpEvmFactory,
 > {
     /// Receipt builder.
-    receipt_builder: R,
+    pub receipt_builder: R,
     /// Chain specification.
-    spec: Spec,
+    pub spec: Spec,
     /// EVM factory.
-    evm_factory: EvmFactory,
+    pub evm_factory: EvmFactory,
 }
 
 impl<R, Spec, EvmFactory> OpBlockExecutorFactory<R, Spec, EvmFactory> {

--- a/crates/op-evm/src/block/mod.rs
+++ b/crates/op-evm/src/block/mod.rs
@@ -264,11 +264,11 @@ pub struct OpBlockExecutorFactory<
     EvmFactory = OpEvmFactory,
 > {
     /// Receipt builder.
-    pub receipt_builder: R,
+    receipt_builder: R,
     /// Chain specification.
-    pub spec: Spec,
+    spec: Spec,
     /// EVM factory.
-    pub evm_factory: EvmFactory,
+    evm_factory: EvmFactory,
 }
 
 impl<R, Spec, EvmFactory> OpBlockExecutorFactory<R, Spec, EvmFactory> {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

I am trying to make customizations to the `OpBlockExecutor`s execution logic, e.g. pre loading receipts, and a bundle into the evm. This is not possible to do without duplicating the code as the fields are not publicly exposed.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
Make all fields pub on `OpBlockExecutor`, and `OpBlockExecutorFactory`

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
