### PR TITLE
feat: generics for PrecompilesMap

### DIFF
--- a/crates/evm/src/precompiles.rs
+++ b/crates/evm/src/precompiles.rs
@@ -12,7 +12,7 @@ use revm::{
     handler::{EthPrecompiles, PrecompileProvider},
     interpreter::{CallInput, Gas, InputsImpl, InstructionResult, InterpreterResult},
     precompile::{PrecompileError, PrecompileFn, PrecompileId, PrecompileResult, Precompiles},
-    Context, Journal,
+    Context,
 };
 
 /// A mapping of precompile contracts that can be either static (builtin) or dynamic.
@@ -345,13 +345,14 @@ impl core::fmt::Debug for PrecompilesMap {
     }
 }
 
-impl<BlockEnv, TxEnv, CfgEnv, DB, Chain, Local>
-    PrecompileProvider<Context<BlockEnv, TxEnv, CfgEnv, DB, Journal<DB>, Chain, Local>>
+impl<BlockEnv, TxEnv, CfgEnv, DB, Journal, Chain, Local>
+    PrecompileProvider<Context<BlockEnv, TxEnv, CfgEnv, DB, Journal, Chain, Local>>
     for PrecompilesMap
 where
     BlockEnv: revm::context::Block,
     TxEnv: revm::context::Transaction,
     CfgEnv: revm::context::Cfg,
+    Journal: revm::context::JournalTr<Database = DB> + Debug,
     Local: revm::context::LocalContextTr,
     DB: Database,
 {
@@ -363,7 +364,7 @@ where
 
     fn run(
         &mut self,
-        context: &mut Context<BlockEnv, TxEnv, CfgEnv, DB, Journal<DB>, Chain, Local>,
+        context: &mut Context<BlockEnv, TxEnv, CfgEnv, DB, Journal, Chain, Local>,
         address: &Address,
         inputs: &InputsImpl,
         _is_static: bool,


### PR DESCRIPTION
There is no benefit in dropping support for generics in PrecompileMap. Some custom EVM implementations may want to make use of LocalContext to store additional data during execution (that doesn't need to be journaled) or make use of a custom Journal.