### PR TITLE
feat: Add next block constructors for `EvmEnv`

### DIFF
--- a/crates/evm/src/eth/mod.rs
+++ b/crates/evm/src/eth/mod.rs
@@ -1,5 +1,6 @@
 //! Ethereum EVM implementation.
 
+pub use env::NextEvmEnvAttributes;
 pub use spec_id::{spec, spec_by_timestamp_and_block_number};
 
 pub(crate) use env::EvmEnvInput;

--- a/crates/evm/src/op/env.rs
+++ b/crates/evm/src/op/env.rs
@@ -1,4 +1,7 @@
-use crate::{eth::EvmEnvInput, EvmEnv};
+use crate::{
+    eth::{EvmEnvInput, NextEvmEnvAttributes},
+    EvmEnv,
+};
 use alloy_consensus::BlockHeader;
 use alloy_op_hardforks::OpHardforks;
 use alloy_primitives::{ChainId, U256};
@@ -37,12 +40,13 @@ impl EvmEnv<OpSpecId> {
     /// * `chain_id` - The chain identifier.
     pub fn for_op_next_block(
         header: impl BlockHeader,
+        attributes: NextEvmEnvAttributes,
         base_fee_per_gas: u64,
         chain_spec: impl OpHardforks,
         chain_id: ChainId,
     ) -> Self {
         Self::for_op(
-            EvmEnvInput::from_parent_header(header, base_fee_per_gas, 0),
+            EvmEnvInput::from_parent_header(header, attributes, base_fee_per_gas, 0),
             chain_spec,
             chain_id,
         )


### PR DESCRIPTION
Part of #170 

## Motivation

The `EvmEnv` is missing constructors for building next block, which is made out of a parent header and some attributes that normally come from block header, but there is no block header yet.

## Solution

Add `for_eth_next_block` and `for_op_next_block` constructors for `EvmEnv`

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
