### PR TITLE
feat(block/result): return custom block execution results

### DIFF
--- a/crates/evm/src/eth/block.rs
+++ b/crates/evm/src/eth/block.rs
@@ -88,6 +88,7 @@ where
     type Transaction = R::Transaction;
     type Receipt = R::Receipt;
     type Evm = E;
+    type BlockExecutionResult = BlockExecutionResult<R::Receipt>;
 
     fn apply_pre_execution_changes(&mut self) -> Result<(), BlockExecutionError> {
         // Set state clear flag if the block is after the Spurious Dragon hardfork.

--- a/crates/evm/src/op/block.rs
+++ b/crates/evm/src/op/block.rs
@@ -1,0 +1,18 @@
+//! Optimism block execution result types.
+
+use crate::block::BlockExecutionResult;
+
+/// The result of executing a block.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct OpBlockExecutionResult<T> {
+    /// Legacy block execution result.
+    pub result: BlockExecutionResult<T>,
+    /// Blob gas usage for the block. This is only relevant after the Jovian hardfork.
+    pub blob_gas_used: Option<u64>,
+}
+
+impl<T> From<BlockExecutionResult<T>> for OpBlockExecutionResult<T> {
+    fn from(result: BlockExecutionResult<T>) -> Self {
+        Self { result, blob_gas_used: None }
+    }
+}

--- a/crates/evm/src/op/mod.rs
+++ b/crates/evm/src/op/mod.rs
@@ -1,6 +1,8 @@
 //! Optimism EVM implementation.
 
+mod block;
 mod env;
 mod spec_id;
 
+pub use block::OpBlockExecutionResult;
 pub use spec_id::{spec, spec_by_timestamp_after_bedrock};


### PR DESCRIPTION
## Description

This PR updates the `BlockExecutor` trait to allow to return custom `BlockExecutionResult`. This allows the `OpBlockExecutor` to return the updated `blob_base_fee` after Jovian.