### PR TITLE
chore: make `EthBlockExecutor` fields public

### DIFF
--- a/crates/evm/src/eth/block.rs
+++ b/crates/evm/src/eth/block.rs
@@ -39,21 +39,21 @@ pub struct EthBlockExecutionCtx<'a> {
 #[derive(Debug)]
 pub struct EthBlockExecutor<'a, Evm, Spec, R: ReceiptBuilder> {
     /// Reference to the specification object.
-    spec: Spec,
+    pub spec: Spec,
 
     /// Context for block execution.
     pub ctx: EthBlockExecutionCtx<'a>,
     /// Inner EVM.
-    evm: Evm,
+    pub evm: Evm,
     /// Utility to call system smart contracts.
-    system_caller: SystemCaller<Spec>,
+    pub system_caller: SystemCaller<Spec>,
     /// Receipt builder.
-    receipt_builder: R,
+    pub receipt_builder: R,
 
     /// Receipts of executed transactions.
-    receipts: Vec<R::Receipt>,
+    pub receipts: Vec<R::Receipt>,
     /// Total gas used by transactions in this block.
-    gas_used: u64,
+    pub gas_used: u64,
 }
 
 impl<'a, Evm, Spec, R> EthBlockExecutor<'a, Evm, Spec, R>


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

This mirrors https://github.com/alloy-rs/evm/pull/178 for `EthBlockExecutor`. I am trying the same here for eth to pre-load an existing state (with receipts, gas_usage) into the executor.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

- Make all fields for `EthBlockExecutor` public
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
