### PR TITLE
chore(deps): bump revm 30+ and update other dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ op-revm = { version = "11.1.0", default-features = false }
 auto_impl = "1"
 derive_more = { version = "2", default-features = false, features = ["full"] }
 serde = { version = "1", default-features = false, features = ["derive"] }
-thiserror = { version = "2.0.0", default-features = false }
+thiserror = { version = "2.0.17", default-features = false }
 serde_json = "1"
 test-case = "3"
 


### PR DESCRIPTION
Bumps revm to 30.1.0

Ref: https://github.com/foundry-rs/foundry/issues/12075
