### PR TITLE
chore(deps): update `alloy-hardforks` deps with the new Jovian timestamps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,12 +45,12 @@ alloy-eips = { version = "1.0.34", default-features = false }
 alloy-consensus = { version = "1.0.27", default-features = false }
 alloy-primitives = { version = "1.0.0", default-features = false }
 alloy-sol-types = { version = "1.0.0", default-features = false }
-alloy-hardforks = { version = "0.4.1" }
+alloy-hardforks = { version = "0.4.2" }
 alloy-rpc-types-eth = { version = "1.0.27", default-features = false }
 alloy-rpc-types-engine = { version = "1.0.27", default-features = false }
 
 # op-alloy
-alloy-op-hardforks = { version = "0.4.1" }
+alloy-op-hardforks = { version = "0.4.2" }
 op-alloy-consensus = { version = "0.21", default-features = false }
 op-alloy-rpc-types-engine = { version = "0.21", default-features = false }
 


### PR DESCRIPTION
## Description

Patches `alloy-hardforks` with the new Jovian timestamps.

Relevant PR: https://github.com/alloy-rs/hardforks/pull/79