### PR TITLE
chore: bump revm v30.0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,8 +55,8 @@ op-alloy-consensus = { version = "0.22", default-features = false }
 op-alloy-rpc-types-engine = { version = "0.22", default-features = false }
 
 # revm
-revm = { version = "31.0.0", default-features = false }
-op-revm = { version = "12.0.0", default-features = false }
+revm = { version = "31.0.2", default-features = false }
+op-revm = { version = "12.0.2", default-features = false }
 
 # misc
 auto_impl = "1"


### PR DESCRIPTION
It is already bumped in Cargo.lock, so only changing Cargo.toml here