### PR TITLE
fix: cleanup op features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,9 +51,7 @@ alloy-rpc-types-engine = { version = "1.0.27", default-features = false }
 
 # op-alloy
 alloy-op-hardforks = { version = "0.4.2" }
-op-alloy-consensus = { version = "0.22", default-features = false }
-op-alloy-rpc-types = { version = "0.22", default-features = false }
-op-alloy-rpc-types-engine = { version = "0.22", default-features = false }
+op-alloy = { version = "0.22", default-features = false, features = ["consensus"] }
 
 # revm
 revm = { version = "32.0.0", default-features = false }

--- a/crates/evm/Cargo.toml
+++ b/crates/evm/Cargo.toml
@@ -22,12 +22,10 @@ alloy-hardforks.workspace = true
 alloy-op-hardforks = { workspace = true, optional = true }
 alloy-rpc-types-eth = { workspace = true, optional = true }
 alloy-rpc-types-engine = { workspace = true, optional = true }
-op-alloy-rpc-types-engine = { workspace = true, optional = true }
 
 revm.workspace = true
 op-revm = { workspace = true, optional = true }
-op-alloy-consensus = { workspace = true, optional = true }
-op-alloy-rpc-types = { workspace = true, optional = true }
+op-alloy = { workspace = true, optional = true }
 
 auto_impl.workspace = true
 derive_more.workspace = true
@@ -53,17 +51,13 @@ std = [
 	"derive_more/std",
 	"op-revm?/std",
 	"thiserror/std",
-	"op-alloy-consensus?/std",
+	"op-alloy?/std",
 	"alloy-rpc-types-eth?/std",
-	"alloy-rpc-types-engine?/std",
-	"op-alloy-rpc-types-engine?/std",
-	"op-alloy-rpc-types?/std"
+	"alloy-rpc-types-engine?/std"
 ]
-op = ["op-revm", "op-alloy-consensus", "alloy-op-hardforks"]
+op = ["op-revm", "op-alloy", "alloy-op-hardforks"]
 overrides = ["dep:alloy-rpc-types-eth"]
 call-util = ["overrides"]
-engine = ["dep:alloy-rpc-types-engine"]
-op-engine = ["dep:op-alloy-rpc-types-engine"]
+engine = ["dep:alloy-rpc-types-engine", "op-alloy?/rpc-types-engine"]
 asm-keccak = ["alloy-primitives/asm-keccak", "revm/asm-keccak"]
-rpc = ["dep:alloy-rpc-types-eth"]
-op-rpc = ["rpc", "dep:op-alloy-rpc-types"]
+rpc = ["dep:alloy-rpc-types-eth", "op-alloy?/rpc-types"]

--- a/crates/evm/src/op/env.rs
+++ b/crates/evm/src/op/env.rs
@@ -79,10 +79,10 @@ impl EvmEnv<OpSpecId> {
     }
 }
 
-#[cfg(feature = "op-engine")]
+#[cfg(feature = "engine")]
 mod payload {
     use super::*;
-    use op_alloy_rpc_types_engine::OpExecutionPayload;
+    use op_alloy::rpc_types_engine::OpExecutionPayload;
 
     impl EvmEnv<OpSpecId> {
         /// Create a new `EvmEnv` with [`OpSpecId`] from a `payload`, `chain_id`, `chain_spec` and

--- a/crates/evm/src/op/mod.rs
+++ b/crates/evm/src/op/mod.rs
@@ -1,7 +1,7 @@
 //! Optimism EVM implementation.
 
 mod env;
-#[cfg(feature = "op-rpc")]
+#[cfg(feature = "rpc")]
 mod rpc;
 mod spec_id;
 mod tx;

--- a/crates/evm/src/op/rpc.rs
+++ b/crates/evm/src/op/rpc.rs
@@ -1,5 +1,5 @@
 use alloy_primitives::Bytes;
-use op_alloy_rpc_types::OpTransactionRequest;
+use op_alloy::rpc_types::OpTransactionRequest;
 use op_revm::OpTransaction;
 use revm::context::{BlockEnv, TxEnv};
 

--- a/crates/evm/src/op/tx.rs
+++ b/crates/evm/src/op/tx.rs
@@ -3,7 +3,7 @@ use crate::{FromRecoveredTx, FromTxWithEncoded};
 use alloy_consensus::{Signed, TxEip1559, TxEip2930, TxEip4844, TxEip7702, TxLegacy};
 use alloy_eips::{Encodable2718, Typed2718};
 use alloy_primitives::{Address, Bytes};
-use op_alloy_consensus::{OpTxEnvelope, TxDeposit};
+use op_alloy::consensus::{OpTxEnvelope, TxDeposit};
 use op_revm::{transaction::deposit::DepositTransactionParts, OpTransaction};
 use revm::context::TxEnv;
 

--- a/crates/op-evm/Cargo.toml
+++ b/crates/op-evm/Cargo.toml
@@ -21,7 +21,7 @@ alloy-consensus.workspace = true
 alloy-primitives.workspace = true
 
 alloy-op-hardforks.workspace = true
-op-alloy-consensus.workspace = true
+op-alloy.workspace = true
 
 revm.workspace = true
 op-revm.workspace = true
@@ -43,7 +43,7 @@ std = [
 	"op-revm/std",
 	"alloy-consensus/std",
 	"alloy-eips/std",
-	"op-alloy-consensus/std",
+	"op-alloy/std",
 	"thiserror/std"
 ]
 asm-keccak = ["alloy-evm/asm-keccak", "alloy-primitives/asm-keccak", "revm/asm-keccak"]

--- a/crates/op-evm/src/block/mod.rs
+++ b/crates/op-evm/src/block/mod.rs
@@ -17,7 +17,7 @@ use alloy_evm::{
 use alloy_op_hardforks::{OpChainHardforks, OpHardforks};
 use alloy_primitives::{Bytes, B256};
 use canyon::ensure_create2_deployer;
-use op_alloy_consensus::OpDepositReceipt;
+use op_alloy::consensus::OpDepositReceipt;
 use op_revm::{
     constants::L1_BLOCK_CONTRACT, estimate_tx_compressed_size,
     transaction::deposit::DEPOSIT_TRANSACTION_TYPE, L1BlockInfo, OpTransaction,
@@ -446,7 +446,7 @@ mod tests {
     use alloy_hardforks::ForkCondition;
     use alloy_op_hardforks::OpHardfork;
     use alloy_primitives::{uint, Address, Signature, U256};
-    use op_alloy_consensus::OpTxEnvelope;
+    use op_alloy::consensus::OpTxEnvelope;
     use op_revm::{
         constants::{
             BASE_FEE_SCALAR_OFFSET, ECOTONE_L1_BLOB_BASE_FEE_SLOT, ECOTONE_L1_FEE_SCALARS_SLOT,

--- a/crates/op-evm/src/block/receipt_builder.rs
+++ b/crates/op-evm/src/block/receipt_builder.rs
@@ -4,7 +4,7 @@
 use alloy_consensus::Eip658Value;
 use alloy_evm::{eth::receipt_builder::ReceiptBuilderCtx, Evm};
 use core::fmt::Debug;
-use op_alloy_consensus::{OpDepositReceipt, OpReceiptEnvelope, OpTxEnvelope, OpTxType};
+use op_alloy::consensus::{OpDepositReceipt, OpReceiptEnvelope, OpTxEnvelope, OpTxType};
 
 /// Type that knows how to build a receipt based on execution result.
 #[auto_impl::auto_impl(&, Arc)]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Removes the need for `op-engine` and `op-rpc` features by depending on `op-alloy` metacrate instead

Not sure if it's worth keeping `op-engine` for backwards compatiblity? We need to do a minor bump for revm release anyway

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
