### PR TITLE
feat(error): add gas limit fns to `InvalidTxError` trait

### DIFF
--- a/crates/evm/src/error.rs
+++ b/crates/evm/src/error.rs
@@ -40,21 +40,6 @@ pub trait InvalidTxError: Error + Send + Sync + Any + 'static {
 }
 
 impl InvalidTxError for InvalidTransaction {
-    fn is_nonce_too_low(&self) -> bool {
-        matches!(self, Self::NonceTooLow { .. })
-    }
-
-    fn is_gas_limit_too_high(&self) -> bool {
-        matches!(self, Self::TxGasLimitGreaterThanCap { .. } | Self::CallerGasLimitMoreThanBlock)
-    }
-
-    fn is_gas_limit_too_low(&self) -> bool {
-        matches!(
-            self,
-            Self::CallGasCostMoreThanGasLimit { .. } | Self::GasFloorMoreThanGasLimit { .. }
-        )
-    }
-
     fn as_invalid_tx_err(&self) -> Option<&InvalidTransaction> {
         Some(self)
     }
@@ -109,18 +94,6 @@ where
 
 #[cfg(feature = "op")]
 impl InvalidTxError for op_revm::OpTransactionError {
-    fn is_nonce_too_low(&self) -> bool {
-        matches!(self, Self::Base(tx) if tx.is_nonce_too_low())
-    }
-
-    fn is_gas_limit_too_high(&self) -> bool {
-        matches!(self, Self::Base(tx) if tx.is_gas_limit_too_high())
-    }
-
-    fn is_gas_limit_too_low(&self) -> bool {
-        matches!(self, Self::Base(tx) if tx.is_gas_limit_too_low())
-    }
-
     fn as_invalid_tx_err(&self) -> Option<&InvalidTransaction> {
         match self {
             Self::Base(tx) => Some(tx),


### PR DESCRIPTION
## Motivation

Towards #225

This would allow to get rid of `AsEthApiError` trait and its impls in Reth https://github.com/paradigmxyz/reth/blob/6598b88e0278a084eabad44573298d5f097b9244/crates/rpc/rpc-eth-types/src/error/api.rs#L53

## Solution

- Add `is_gas_limit_too_high` and `is_gas_limit_too_high` fns to `InvalidTxError` trait
- Add default impls to  `InvalidTxError` trait using `as_invalid_tx_err`

## PR Checklist

- [ ] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
