### PR TITLE
feat: complete migration to StateDB

### DIFF
--- a/crates/evm/src/block/mod.rs
+++ b/crates/evm/src/block/mod.rs
@@ -1,6 +1,6 @@
 //! Block execution abstraction.
 
-use crate::{Database, Evm, EvmFactory, FromRecoveredTx, FromTxWithEncoded, RecoveredTx, ToTxEnv};
+use crate::{Evm, EvmFactory, FromRecoveredTx, FromTxWithEncoded, RecoveredTx, ToTxEnv};
 use alloc::{boxed::Box, vec::Vec};
 use alloy_consensus::transaction::Recovered;
 use alloy_eips::{eip2718::WithEncoded, eip7685::Requests};
@@ -8,7 +8,7 @@ use revm::{
     context::result::{ExecutionResult, ResultAndState},
     context_interface::either::Either,
     inspector::NoOpInspector,
-    DatabaseCommit, Inspector,
+    Inspector,
 };
 
 mod error;
@@ -443,7 +443,7 @@ where
         Transaction = F::Transaction,
         Receipt = F::Receipt,
     >,
-    DB: Database + DatabaseCommit + StateDB + 'a,
+    DB: StateDB + 'a,
     I: Inspector<<F::EvmFactory as EvmFactory>::Context<DB>> + 'a,
 {
 }
@@ -451,7 +451,7 @@ where
 impl<'a, F, DB, I, T> BlockExecutorFor<'a, F, DB, I> for T
 where
     F: BlockExecutorFactory,
-    DB: Database + DatabaseCommit + StateDB + 'a,
+    DB: StateDB + 'a,
     I: Inspector<<F::EvmFactory as EvmFactory>::Context<DB>> + 'a,
     T: BlockExecutor<
         Evm = <F::EvmFactory as EvmFactory>::Evm<DB, I>,
@@ -582,6 +582,6 @@ pub trait BlockExecutorFactory: 'static {
         ctx: Self::ExecutionCtx<'a>,
     ) -> impl BlockExecutorFor<'a, Self, DB, I>
     where
-        DB: Database + DatabaseCommit + StateDB + 'a,
+        DB: StateDB + 'a,
         I: Inspector<<Self::EvmFactory as EvmFactory>::Context<DB>> + 'a;
 }

--- a/crates/evm/src/block/state.rs
+++ b/crates/evm/src/block/state.rs
@@ -1,23 +1,18 @@
 //! State database abstraction.
 
-use revm::database::State;
+use crate::Database;
+use revm::{database::State, DatabaseCommit};
 
 /// A type which has the state of the blockchain.
 ///
 /// This trait encapsulates some of the functionality found in [`State`]
-pub trait StateDB: revm::Database {
+#[auto_impl::auto_impl(&mut, Box)]
+pub trait StateDB: Database + DatabaseCommit {
     /// State clear EIP-161 is enabled in Spurious Dragon hardfork.
     fn set_state_clear_flag(&mut self, has_state_clear: bool);
 }
 
-/// auto_impl unable to reconcile return associated type from supertrait
-impl<T: StateDB> StateDB for &mut T {
-    fn set_state_clear_flag(&mut self, has_state_clear: bool) {
-        StateDB::set_state_clear_flag(*self, has_state_clear);
-    }
-}
-
-impl<DB: revm::Database> StateDB for State<DB> {
+impl<DB: Database> StateDB for State<DB> {
     fn set_state_clear_flag(&mut self, has_state_clear: bool) {
         self.cache.set_state_clear_flag(has_state_clear);
     }

--- a/crates/evm/src/eth/block.rs
+++ b/crates/evm/src/eth/block.rs
@@ -13,7 +13,7 @@ use crate::{
         BlockExecutorFor, BlockValidationError, ExecutableTx, OnStateHook,
         StateChangePostBlockSource, StateChangeSource, StateDB, SystemCaller, TxResult,
     },
-    Database, Evm, EvmFactory, FromRecoveredTx, FromTxWithEncoded, RecoveredTx,
+    Evm, EvmFactory, FromRecoveredTx, FromTxWithEncoded, RecoveredTx,
 };
 use alloc::{borrow::Cow, boxed::Box, vec::Vec};
 use alloy_consensus::{Header, Transaction, TransactionEnvelope, TxReceipt};
@@ -109,10 +109,7 @@ where
 
 impl<E, Spec, R> BlockExecutor for EthBlockExecutor<'_, E, Spec, R>
 where
-    E: Evm<
-        DB: Database + DatabaseCommit + StateDB,
-        Tx: FromRecoveredTx<R::Transaction> + FromTxWithEncoded<R::Transaction>,
-    >,
+    E: Evm<DB: StateDB, Tx: FromRecoveredTx<R::Transaction> + FromTxWithEncoded<R::Transaction>>,
     Spec: EthExecutorSpec,
     R: ReceiptBuilder<Transaction: Transaction + Encodable2718, Receipt: TxReceipt<Log = Log>>,
 {
@@ -348,7 +345,7 @@ where
         ctx: Self::ExecutionCtx<'a>,
     ) -> impl BlockExecutorFor<'a, Self, DB, I>
     where
-        DB: Database + DatabaseCommit + StateDB + 'a,
+        DB: StateDB + 'a,
         I: Inspector<EvmF::Context<DB>> + 'a,
     {
         EthBlockExecutor::new(evm, ctx, &self.spec, &self.receipt_builder)


### PR DESCRIPTION
See #234 for context

This PR completes the transition from the concrete `State<DB>` to `StateDB`. We must introduce the fn `drain_balances` to accomplish this. Both `drain_balances` and `increment_balances` should be implementable with DatabaseCommit + Database which is why I have [this PR open in revm](https://github.com/bluealloy/revm/pull/3195). If this is accepted then it should be possible to remove these methods. Alternatively, `DatabaseCommitExt` could be moved here.

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [x] No Breaking changes from latest release.
