### PR TITLE
feat: Clean up StateDB methods, bump revm

### DIFF
--- a/crates/evm/src/block/state.rs
+++ b/crates/evm/src/block/state.rs
@@ -1,5 +1,6 @@
 //! State database abstraction.
 
+use core::fmt::Debug;
 use revm::{
     database::{states::bundle_state::BundleRetention, BundleState, State},
     DatabaseCommit,
@@ -40,7 +41,7 @@ pub trait StateDB: Database + DatabaseCommit {
     fn merge_transitions(&mut self, retention: BundleRetention);
 }
 
-impl<DB: revm::Database + std::fmt::Debug> StateDB for State<DB> {
+impl<DB: revm::Database + Debug> StateDB for State<DB> {
     fn set_state_clear_flag(&mut self, has_state_clear: bool) {
         Self::set_state_clear_flag(self, has_state_clear);
     }

--- a/crates/evm/src/block/state.rs
+++ b/crates/evm/src/block/state.rs
@@ -13,9 +13,6 @@ use crate::Database;
 /// This trait encapsulates some of the functionality found in [`State`]
 #[auto_impl::auto_impl(&mut, Box)]
 pub trait StateDB: Database + DatabaseCommit {
-    /// State clear EIP-161 is enabled in Spurious Dragon hardfork.
-    fn set_state_clear_flag(&mut self, has_state_clear: bool);
-
     /// Gets a reference to the internal [`BundleState`]
     fn bundle_state(&self) -> &BundleState;
 
@@ -42,10 +39,6 @@ pub trait StateDB: Database + DatabaseCommit {
 }
 
 impl<DB: revm::Database + Debug> StateDB for State<DB> {
-    fn set_state_clear_flag(&mut self, has_state_clear: bool) {
-        Self::set_state_clear_flag(self, has_state_clear);
-    }
-
     fn bundle_state(&self) -> &BundleState {
         &self.bundle_state
     }

--- a/crates/evm/src/block/state.rs
+++ b/crates/evm/src/block/state.rs
@@ -1,9 +1,59 @@
 //! State database abstraction.
 
+use revm::{
+    database::{states::bundle_state::BundleRetention, BundleState, State},
+    DatabaseCommit,
+};
+
 use crate::Database;
-use revm::DatabaseCommit;
 
-/// Alias trait for [`Database`] and [`DatabaseCommit`].
-pub trait StateDB: Database + DatabaseCommit {}
+/// A type which has the state of the blockchain.
+///
+/// This trait encapsulates some of the functionality found in [`State`]
+#[auto_impl::auto_impl(&mut, Box)]
+pub trait StateDB: Database + DatabaseCommit {
+    /// State clear EIP-161 is enabled in Spurious Dragon hardfork.
+    fn set_state_clear_flag(&mut self, has_state_clear: bool);
 
-impl<T> StateDB for T where T: Database + DatabaseCommit {}
+    /// Gets a reference to the internal [`BundleState`]
+    fn bundle_state(&self) -> &BundleState;
+
+    /// Gets a mutable reference to the internal [`BundleState`]
+    fn bundle_state_mut(&mut self) -> &mut BundleState;
+
+    /// This will not apply any pending [`revm::database::TransitionState`].
+    ///
+    /// It is recommended to call [`StateDB::merge_transitions`] before taking the bundle.
+    ///
+    /// If the `State` has been built with the
+    /// [`revm::database::StateBuilder::with_bundle_prestate`] option, the pre-state will be
+    /// taken along with any changes made by [`StateDB::merge_transitions`].
+    fn take_bundle(&mut self) -> BundleState {
+        core::mem::take(self.bundle_state_mut())
+    }
+
+    /// Take all transitions and merge them inside [`BundleState`].
+    ///
+    /// This action will create final post state and all reverts so that
+    /// we at any time revert state of bundle to the state before transition
+    /// is applied.
+    fn merge_transitions(&mut self, retention: BundleRetention);
+}
+
+impl<DB: revm::Database + std::fmt::Debug> StateDB for State<DB> {
+    fn set_state_clear_flag(&mut self, has_state_clear: bool) {
+        Self::set_state_clear_flag(self, has_state_clear);
+    }
+
+    fn bundle_state(&self) -> &BundleState {
+        &self.bundle_state
+    }
+
+    fn bundle_state_mut(&mut self) -> &mut BundleState {
+        &mut self.bundle_state
+    }
+
+    fn merge_transitions(&mut self, retention: BundleRetention) {
+        Self::merge_transitions(self, retention);
+    }
+}


### PR DESCRIPTION
This PR removes unnecessary methods from `StateDB` in favour of using `DatabaseCommitExt`. See #234 and [this pr](https://github.com/bluealloy/revm/pull/3205) for more details.

Additionally we've added a few more trait methods to abstract away from `revm::State`.

You can see why this is required by taking a look at [this pr into reth](https://github.com/paradigmxyz/reth/pull/22098).
## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [x] Breaking changes
