### PR TITLE
feat(tx): add IntoTxParts trait for zero-copy transaction decomposition

### DIFF
--- a/crates/evm/src/block/mod.rs
+++ b/crates/evm/src/block/mod.rs
@@ -1,6 +1,8 @@
 //! Block execution abstraction.
 
-use crate::{Database, Evm, EvmFactory, FromRecoveredTx, FromTxWithEncoded, IntoTxParts};
+use crate::{
+    Database, Evm, EvmFactory, FromRecoveredTx, FromTxWithEncoded, IntoTxParts, RecoveredTx,
+};
 use alloc::{boxed::Box, vec::Vec};
 use alloy_eips::eip7685::Requests;
 use revm::{
@@ -261,11 +263,11 @@ pub trait BlockExecutor {
     ///
     /// # Parameters
     /// - `output`: The transaction output containing execution result and state changes
-    /// - `tx`: The original transaction (needed for receipt generation)
+    /// - `tx`: The original transaction (needed for receipt generation via [`RecoveredTx`])
     fn commit_transaction(
         &mut self,
         output: ResultAndState<<Self::Evm as Evm>::HaltReason>,
-        tx: impl ExecutableTx<Self>,
+        tx: impl RecoveredTx<Self::Transaction>,
     ) -> Result<u64, BlockExecutionError>;
 
     /// Applies any necessary changes after executing the block's transactions, completes execution

--- a/crates/evm/src/eth/block.rs
+++ b/crates/evm/src/eth/block.rs
@@ -146,7 +146,7 @@ where
     fn commit_transaction(
         &mut self,
         output: ResultAndState<<Self::Evm as Evm>::HaltReason>,
-        tx: impl ExecutableTx<Self>,
+        tx: impl RecoveredTx<R::Transaction>,
     ) -> Result<u64, BlockExecutionError> {
         let ResultAndState { result, state } = output;
 

--- a/crates/evm/src/tx.rs
+++ b/crates/evm/src/tx.rs
@@ -530,6 +530,12 @@ impl<Eip4844: AsRef<TxEip4844>> FromRecoveredTx<EthereumTxEnvelope<Eip4844>> for
 /// 1. The EVM needs to consume the `TxEnv` for execution
 /// 2. The executor needs access to the original transaction for receipt generation
 ///
+/// # Supertraits
+///
+/// This trait requires [`ToTxEnv`] and [`RecoveredTx`] as supertraits, ensuring that types
+/// implementing this trait can be used interchangeably with the traditional approach of
+/// borrowing for `TxEnv` conversion and transaction access.
+///
 /// # Example
 ///
 /// ```ignore
@@ -547,7 +553,7 @@ impl<Eip4844: AsRef<TxEip4844>> FromRecoveredTx<EthereumTxEnvelope<Eip4844>> for
 ///     }
 /// }
 /// ```
-pub trait IntoTxParts<TxEnv, Tx> {
+pub trait IntoTxParts<TxEnv, Tx>: ToTxEnv<TxEnv> + RecoveredTx<Tx> {
     /// The remainder type that still provides access to the original transaction.
     type Remainder: RecoveredTx<Tx>;
 


### PR DESCRIPTION
## Summary

Adds `IntoTxParts` trait that enables splitting a transaction into:
- `TxEnv`: consumed by the EVM (can be zero-copy for owned types)
- `Remainder`: retains `RecoveredTx` access for receipt building

## Motivation

This follows the `into_parts()` pattern from std (`BufWriter::into_parts()`, `http::Request::into_parts()`).

Currently in block execution, we pass `&tx` to `execute_transaction_without_commit` which goes through `ToTxEnv` and clones. With `IntoTxParts`, wrapper types that own a pre-built `TxEnv` can provide it without cloning:

```rust
struct WithTxEnv<E, T> {
    tx_env: E,
    tx: Recovered<T>,
}

impl<E, T> IntoTxParts<E, T> for WithTxEnv<E, Recovered<T>> {
    type Remainder = Recovered<T>;
    
    fn into_tx_parts(self) -> (E, Self::Remainder) {
        (self.tx_env, self.tx)  // Zero-copy extraction
    }
}
```

## Changes

- Add `IntoTxParts` trait with blanket impls for:
  - `Recovered<T>`
  - `WithEncoded<Recovered<T>>`
  - References via blanket impl
- Update `ExecutableTx` to require both `ToTxEnv` and `IntoTxParts`
- Add tests for the new trait

## Related

This complements #256 (zero-copy `IntoTxEnv`) by enabling the same optimization in the block executor context where we need to split the transaction for EVM execution and receipt building.