### PR TITLE
feat(block): zero-copy transaction execution via TxParts

### DIFF
--- a/crates/evm/src/block/mod.rs
+++ b/crates/evm/src/block/mod.rs
@@ -242,11 +242,11 @@ pub trait BlockExecutor {
     ///
     /// # Parameters
     /// - `tx_env`: The transaction environment to execute (consumed)
-    /// - `tx`: Reference to recovered transaction for validation (gas limit checks)
+    /// - `tx`: Recovered transaction for validation (gas limit checks)
     fn execute_transaction_without_commit_with_parts(
         &mut self,
         tx_env: <Self::Evm as Evm>::Tx,
-        tx: &impl RecoveredTx<Self::Transaction>,
+        tx: impl RecoveredTx<Self::Transaction>,
     ) -> Result<ResultAndState<<Self::Evm as Evm>::HaltReason>, BlockExecutionError>;
 
     /// Executes a single transaction without committing state changes.

--- a/crates/evm/src/eth/block.rs
+++ b/crates/evm/src/eth/block.rs
@@ -120,7 +120,7 @@ where
     fn execute_transaction_without_commit_with_parts(
         &mut self,
         tx_env: <Self::Evm as Evm>::Tx,
-        tx: &impl RecoveredTx<R::Transaction>,
+        tx: impl RecoveredTx<R::Transaction>,
     ) -> Result<ResultAndState<<Self::Evm as Evm>::HaltReason>, BlockExecutionError> {
         // The sum of the transaction's gas limit, Tg, and the gas utilized in this block prior,
         // must be no greater than the block's gasLimit.

--- a/crates/op-evm/src/block/mod.rs
+++ b/crates/op-evm/src/block/mod.rs
@@ -142,7 +142,7 @@ where
     fn jovian_da_footprint_estimation(
         &mut self,
         tx_env: &E::Tx,
-        tx: &impl RecoveredTx<R::Transaction>,
+        tx: impl RecoveredTx<R::Transaction>,
     ) -> Result<u64, BlockExecutionError> {
         // Try to use the enveloped tx if it exists, otherwise use the encoded 2718 bytes
         let encoded = match tx_env.encoded_bytes() {
@@ -203,7 +203,7 @@ where
     fn execute_transaction_without_commit_with_parts(
         &mut self,
         tx_env: <Self::Evm as Evm>::Tx,
-        tx: &impl RecoveredTx<R::Transaction>,
+        tx: impl RecoveredTx<R::Transaction>,
     ) -> Result<ResultAndState<<Self::Evm as Evm>::HaltReason>, BlockExecutionError> {
         let is_deposit = tx.tx().ty() == DEPOSIT_TRANSACTION_TYPE;
 
@@ -226,7 +226,7 @@ where
         {
             let da_footprint_available = self.evm.block().gas_limit() - self.da_footprint_used;
 
-            let tx_da_footprint = self.jovian_da_footprint_estimation(&tx_env, tx)?;
+            let tx_da_footprint = self.jovian_da_footprint_estimation(&tx_env, &tx)?;
 
             if tx_da_footprint > da_footprint_available {
                 return Err(BlockExecutionError::Validation(BlockValidationError::Other(
@@ -443,7 +443,7 @@ mod tests {
     use alloc::{string::ToString, vec};
     use alloy_consensus::{transaction::Recovered, SignableTransaction, TxLegacy};
     use alloy_eips::eip2718::WithEncoded;
-    use alloy_evm::EvmEnv;
+    use alloy_evm::{EvmEnv, ToTxEnv};
     use alloy_hardforks::ForkCondition;
     use alloy_op_hardforks::OpHardfork;
     use alloy_primitives::{uint, Address, Signature, U256};


### PR DESCRIPTION
## Summary

Introduces zero-copy transaction execution optimization for the BlockExecutor trait via a new `TxParts` abstraction.

## Changes

### New Types in `crates/evm/src/tx.rs`

- **`TxParts<E, R>`**: Container holding both the EVM transaction environment (`tx_env`) and the recovered transaction data (`recovered`). Enables the `tx_env` to be consumed by the EVM while retaining access to the original transaction for receipt generation.

- **`IntoTxParts`**: Trait for types that can be decomposed into `TxParts`. Implemented for:
  - `Recovered<T>` - builds `TxEnv` via `FromRecoveredTx`
  - `WithEncoded<Recovered<T>>` - builds `TxEnv` via `FromTxWithEncoded`
  - References - clones `TxEnv`, borrows for `RecoveredTx`
  - `TxParts` itself - just moves the fields

### BlockExecutor Changes in `crates/evm/src/block/mod.rs`

- **`ExecutableTx`**: Now requires `IntoTxParts` instead of just `ToTxEnv + RecoveredTx`

- **`execute_transaction_with_commit_condition`**: Refactored default implementation to:
  1. Call `tx.into_tx_parts()` to split the transaction
  2. Call `execute_transaction_without_commit_with_parts(tx_env, &recovered)` - consumes `tx_env` by value
  3. Call `commit_transaction(output, recovered)`

- **`execute_transaction_without_commit_with_parts`**: New method that takes `tx_env` by value for zero-copy consumption

- **`commit_transaction`**: Now accepts `impl RecoveredTx` instead of `impl ExecutableTx`

### EthBlockExecutor Changes

- Implemented `execute_transaction_without_commit_with_parts` that consumes `tx_env` directly

### OpBlockExecutor Changes

- Implemented `execute_transaction_without_commit_with_parts`
- Added `pending_tx_da_footprint` field to store DA footprint computed during execution
- DA footprint is computed once in execution, applied during commit

## Motivation

This enables zero-copy `TxEnv` consumption for `transact()` calls, particularly beneficial for types like `WithTxEnv<TxEnv, Arc<T>>` that pre-compute the transaction environment.

## Testing

- Existing tests pass
- Added compile-time tests for `IntoTxParts` implementations