### PR TITLE
EIP-7778: add new gas_spent field in receipts

### DIFF
--- a/crates/evm/src/eth/block.rs
+++ b/crates/evm/src/eth/block.rs
@@ -190,15 +190,17 @@ where
         }
 
         // EIP-7778: Track refunds and compute gross gas for Amsterdam
-        let cumulative_gas_used =
-            if self.spec.is_amsterdam_active_at_timestamp(self.evm.block().timestamp().saturating_to()) {
-                if let ExecutionResult::Success { gas_refunded, .. } = &result {
-                    self.gas_refunded = self.gas_refunded.saturating_add(*gas_refunded);
-                }
-                self.gas_used + self.gas_refunded
-            } else {
-                self.gas_used
-            };
+        let cumulative_gas_used = if self
+            .spec
+            .is_amsterdam_active_at_timestamp(self.evm.block().timestamp().saturating_to())
+        {
+            if let ExecutionResult::Success { gas_refunded, .. } = &result {
+                self.gas_refunded = self.gas_refunded.saturating_add(*gas_refunded);
+            }
+            self.gas_used + self.gas_refunded
+        } else {
+            self.gas_used
+        };
 
         // Push transaction changeset and calculate header bloom filter for receipt.
         self.receipts.push(self.receipt_builder.build_receipt(ReceiptBuilderCtx {

--- a/crates/evm/src/eth/block.rs
+++ b/crates/evm/src/eth/block.rs
@@ -22,7 +22,7 @@ use alloy_hardforks::EthereumHardfork;
 use alloy_primitives::{Bytes, Log, B256};
 use revm::{
     context::Block,
-    context_interface::result::ResultAndState,
+    context_interface::result::{ExecutionResult, ResultAndState},
     database::{DatabaseCommitExt, State},
     DatabaseCommit, Inspector,
 };
@@ -67,6 +67,11 @@ pub struct EthBlockExecutor<'a, Evm, Spec, R: ReceiptBuilder> {
     /// Blob gas used by the block.
     /// Before cancun activation, this is always 0.
     pub blob_gas_used: u64,
+
+    /// Total gas refunded by transactions in this block.
+    /// Before amsterdam activation, this is always 0.
+    /// Used for EIP-7778 block gas accounting.
+    pub gas_refunded: u64,
 }
 
 /// The result of executing an Ethereum transaction.
@@ -102,6 +107,7 @@ where
             receipts: Vec::with_capacity(tx_count_hint),
             gas_used: 0,
             blob_gas_used: 0,
+            gas_refunded: 0,
             system_caller: SystemCaller::new(spec.clone()),
             spec,
             receipt_builder,
@@ -184,13 +190,30 @@ where
             self.blob_gas_used = self.blob_gas_used.saturating_add(blob_gas_used);
         }
 
+        // EIP-7778: track gas refunds when amsterdam is active.
+        // Refunds reduce user cost (gas_spent) but not block gas limit (cumulative_gas_used).
+        let is_amsterdam =
+            self.spec.is_amsterdam_active_at_timestamp(self.evm.block().timestamp().saturating_to());
+        if is_amsterdam {
+            if let ExecutionResult::Success { gas_refunded, .. } = &result {
+                self.gas_refunded = self.gas_refunded.saturating_add(*gas_refunded);
+            }
+        }
+
+        // EIP-7778: cumulative_gas_used is gross gas (before refunds) when amsterdam is active
+        let cumulative_gas_used = if is_amsterdam {
+            self.gas_used + self.gas_refunded
+        } else {
+            self.gas_used
+        };
+
         // Push transaction changeset and calculate header bloom filter for receipt.
         self.receipts.push(self.receipt_builder.build_receipt(ReceiptBuilderCtx {
             tx_type,
             evm: &self.evm,
             result,
             state: &state,
-            cumulative_gas_used: self.gas_used,
+            cumulative_gas_used,
         }));
 
         // Commit the state changes.

--- a/crates/evm/src/eth/spec_id.rs
+++ b/crates/evm/src/eth/spec_id.rs
@@ -21,7 +21,9 @@ pub fn spec_by_timestamp_and_block_number<C>(
 where
     C: EthereumHardforks,
 {
-    if chain_spec.is_osaka_active_at_timestamp(timestamp) {
+    if chain_spec.is_amsterdam_active_at_timestamp(timestamp) {
+        SpecId::AMSTERDAM
+    } else if chain_spec.is_osaka_active_at_timestamp(timestamp) {
         SpecId::OSAKA
     } else if chain_spec.is_prague_active_at_timestamp(timestamp) {
         SpecId::PRAGUE
@@ -75,6 +77,10 @@ mod tests {
     }
 
     impl FakeHardfork {
+        fn amsterdam() -> Self {
+            Self::from_timestamp_zero(EthereumHardfork::Amsterdam)
+        }
+
         fn osaka() -> Self {
             Self::from_timestamp_zero(EthereumHardfork::Osaka)
         }
@@ -142,6 +148,7 @@ mod tests {
         }
     }
 
+    #[test_case::test_case(FakeHardfork::amsterdam(), SpecId::AMSTERDAM; "Amsterdam")]
     #[test_case::test_case(FakeHardfork::osaka(), SpecId::OSAKA; "Osaka")]
     #[test_case::test_case(FakeHardfork::prague(), SpecId::PRAGUE; "Prague")]
     #[test_case::test_case(FakeHardfork::cancun(), SpecId::CANCUN; "Cancun")]


### PR DESCRIPTION
EIP-7778 introduces a new gas_spent field in receipts to track per-transaction gas after refunds (what users actually pay). This separates it from cumulative_gas_used, which now represents gas before refunds for block limit enforcement. This PR adds the executor-side tracking needed to compute gross gas by accumulating refunds in EthBlockExecutor and adjusting cumulative_gas_used to include them when Amsterdam is active.