### PR TITLE
chore: update revm to staging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,16 +68,16 @@ serde_json = "1"
 test-case = "3"
 
 [patch.crates-io]
-revm = { git = "https://github.com/bluealloy/revm", rev = "f3b74d4ff0c6c88a09ca281323a100257fa61ebf" }
-op-revm = { git = "https://github.com/bluealloy/revm", rev = "f3b74d4ff0c6c88a09ca281323a100257fa61ebf" }
-revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "f3b74d4ff0c6c88a09ca281323a100257fa61ebf" }
-revm-context = { git = "https://github.com/bluealloy/revm", rev = "f3b74d4ff0c6c88a09ca281323a100257fa61ebf" }
-revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "f3b74d4ff0c6c88a09ca281323a100257fa61ebf" }
-revm-database = { git = "https://github.com/bluealloy/revm", rev = "f3b74d4ff0c6c88a09ca281323a100257fa61ebf" }
-revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "f3b74d4ff0c6c88a09ca281323a100257fa61ebf" }
-revm-handler = { git = "https://github.com/bluealloy/revm", rev = "f3b74d4ff0c6c88a09ca281323a100257fa61ebf" }
-revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "f3b74d4ff0c6c88a09ca281323a100257fa61ebf" }
-revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "f3b74d4ff0c6c88a09ca281323a100257fa61ebf" }
-revm-precompile = { git = "https://github.com/bluealloy/revm", rev = "f3b74d4ff0c6c88a09ca281323a100257fa61ebf" }
-revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "f3b74d4ff0c6c88a09ca281323a100257fa61ebf" }
-revm-state = { git = "https://github.com/bluealloy/revm", rev = "f3b74d4ff0c6c88a09ca281323a100257fa61ebf" }
+revm = { git = "https://github.com/bluealloy/revm", rev = "6aa06829d2caa2aa38606ed22b83354a7a7ff98e" }
+op-revm = { git = "https://github.com/bluealloy/revm", rev = "6aa06829d2caa2aa38606ed22b83354a7a7ff98e" }
+revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "6aa06829d2caa2aa38606ed22b83354a7a7ff98e" }
+revm-context = { git = "https://github.com/bluealloy/revm", rev = "6aa06829d2caa2aa38606ed22b83354a7a7ff98e" }
+revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "6aa06829d2caa2aa38606ed22b83354a7a7ff98e" }
+revm-database = { git = "https://github.com/bluealloy/revm", rev = "6aa06829d2caa2aa38606ed22b83354a7a7ff98e" }
+revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "6aa06829d2caa2aa38606ed22b83354a7a7ff98e" }
+revm-handler = { git = "https://github.com/bluealloy/revm", rev = "6aa06829d2caa2aa38606ed22b83354a7a7ff98e" }
+revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "6aa06829d2caa2aa38606ed22b83354a7a7ff98e" }
+revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "6aa06829d2caa2aa38606ed22b83354a7a7ff98e" }
+revm-precompile = { git = "https://github.com/bluealloy/revm", rev = "6aa06829d2caa2aa38606ed22b83354a7a7ff98e" }
+revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "6aa06829d2caa2aa38606ed22b83354a7a7ff98e" }
+revm-state = { git = "https://github.com/bluealloy/revm", rev = "6aa06829d2caa2aa38606ed22b83354a7a7ff98e" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,16 +68,16 @@ serde_json = "1"
 test-case = "3"
 
 [patch.crates-io]
-revm = { git = "https://github.com/bluealloy/revm", branch = "staging" }
-op-revm = { git = "https://github.com/bluealloy/revm", branch = "staging" }
-revm-bytecode = { git = "https://github.com/bluealloy/revm", branch = "staging" }
-revm-context = { git = "https://github.com/bluealloy/revm", branch = "staging" }
-revm-context-interface = { git = "https://github.com/bluealloy/revm", branch = "staging" }
-revm-database = { git = "https://github.com/bluealloy/revm", branch = "staging" }
-revm-database-interface = { git = "https://github.com/bluealloy/revm", branch = "staging" }
-revm-handler = { git = "https://github.com/bluealloy/revm", branch = "staging" }
-revm-inspector = { git = "https://github.com/bluealloy/revm", branch = "staging" }
-revm-interpreter = { git = "https://github.com/bluealloy/revm", branch = "staging" }
-revm-precompile = { git = "https://github.com/bluealloy/revm", branch = "staging" }
-revm-primitives = { git = "https://github.com/bluealloy/revm", branch = "staging" }
-revm-state = { git = "https://github.com/bluealloy/revm", branch = "staging" }
+revm = { git = "https://github.com/bluealloy/revm", rev = "300efbf3e391e1796f5210cd4506508e385a55d2" }
+op-revm = { git = "https://github.com/bluealloy/revm", rev = "300efbf3e391e1796f5210cd4506508e385a55d2" }
+revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "300efbf3e391e1796f5210cd4506508e385a55d2" }
+revm-context = { git = "https://github.com/bluealloy/revm", rev = "300efbf3e391e1796f5210cd4506508e385a55d2" }
+revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "300efbf3e391e1796f5210cd4506508e385a55d2" }
+revm-database = { git = "https://github.com/bluealloy/revm", rev = "300efbf3e391e1796f5210cd4506508e385a55d2" }
+revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "300efbf3e391e1796f5210cd4506508e385a55d2" }
+revm-handler = { git = "https://github.com/bluealloy/revm", rev = "300efbf3e391e1796f5210cd4506508e385a55d2" }
+revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "300efbf3e391e1796f5210cd4506508e385a55d2" }
+revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "300efbf3e391e1796f5210cd4506508e385a55d2" }
+revm-precompile = { git = "https://github.com/bluealloy/revm", rev = "300efbf3e391e1796f5210cd4506508e385a55d2" }
+revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "300efbf3e391e1796f5210cd4506508e385a55d2" }
+revm-state = { git = "https://github.com/bluealloy/revm", rev = "300efbf3e391e1796f5210cd4506508e385a55d2" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,3 +66,18 @@ serde = { version = "1", default-features = false, features = ["derive"] }
 thiserror = { version = "2.0.0", default-features = false }
 serde_json = "1"
 test-case = "3"
+
+[patch.crates-io]
+revm = { git = "https://github.com/bluealloy/revm", branch = "staging" }
+op-revm = { git = "https://github.com/bluealloy/revm", branch = "staging" }
+revm-bytecode = { git = "https://github.com/bluealloy/revm", branch = "staging" }
+revm-context = { git = "https://github.com/bluealloy/revm", branch = "staging" }
+revm-context-interface = { git = "https://github.com/bluealloy/revm", branch = "staging" }
+revm-database = { git = "https://github.com/bluealloy/revm", branch = "staging" }
+revm-database-interface = { git = "https://github.com/bluealloy/revm", branch = "staging" }
+revm-handler = { git = "https://github.com/bluealloy/revm", branch = "staging" }
+revm-inspector = { git = "https://github.com/bluealloy/revm", branch = "staging" }
+revm-interpreter = { git = "https://github.com/bluealloy/revm", branch = "staging" }
+revm-precompile = { git = "https://github.com/bluealloy/revm", branch = "staging" }
+revm-primitives = { git = "https://github.com/bluealloy/revm", branch = "staging" }
+revm-state = { git = "https://github.com/bluealloy/revm", branch = "staging" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,16 +68,16 @@ serde_json = "1"
 test-case = "3"
 
 [patch.crates-io]
-revm = { git = "https://github.com/bluealloy/revm", rev = "6aa06829d2caa2aa38606ed22b83354a7a7ff98e" }
-op-revm = { git = "https://github.com/bluealloy/revm", rev = "6aa06829d2caa2aa38606ed22b83354a7a7ff98e" }
-revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "6aa06829d2caa2aa38606ed22b83354a7a7ff98e" }
-revm-context = { git = "https://github.com/bluealloy/revm", rev = "6aa06829d2caa2aa38606ed22b83354a7a7ff98e" }
-revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "6aa06829d2caa2aa38606ed22b83354a7a7ff98e" }
-revm-database = { git = "https://github.com/bluealloy/revm", rev = "6aa06829d2caa2aa38606ed22b83354a7a7ff98e" }
-revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "6aa06829d2caa2aa38606ed22b83354a7a7ff98e" }
-revm-handler = { git = "https://github.com/bluealloy/revm", rev = "6aa06829d2caa2aa38606ed22b83354a7a7ff98e" }
-revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "6aa06829d2caa2aa38606ed22b83354a7a7ff98e" }
-revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "6aa06829d2caa2aa38606ed22b83354a7a7ff98e" }
-revm-precompile = { git = "https://github.com/bluealloy/revm", rev = "6aa06829d2caa2aa38606ed22b83354a7a7ff98e" }
-revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "6aa06829d2caa2aa38606ed22b83354a7a7ff98e" }
-revm-state = { git = "https://github.com/bluealloy/revm", rev = "6aa06829d2caa2aa38606ed22b83354a7a7ff98e" }
+revm = { git = "https://github.com/bluealloy/revm", rev = "33330a285e621b9170c30a21cfea9ab32e2a2169" }
+op-revm = { git = "https://github.com/bluealloy/revm", rev = "33330a285e621b9170c30a21cfea9ab32e2a2169" }
+revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "33330a285e621b9170c30a21cfea9ab32e2a2169" }
+revm-context = { git = "https://github.com/bluealloy/revm", rev = "33330a285e621b9170c30a21cfea9ab32e2a2169" }
+revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "33330a285e621b9170c30a21cfea9ab32e2a2169" }
+revm-database = { git = "https://github.com/bluealloy/revm", rev = "33330a285e621b9170c30a21cfea9ab32e2a2169" }
+revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "33330a285e621b9170c30a21cfea9ab32e2a2169" }
+revm-handler = { git = "https://github.com/bluealloy/revm", rev = "33330a285e621b9170c30a21cfea9ab32e2a2169" }
+revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "33330a285e621b9170c30a21cfea9ab32e2a2169" }
+revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "33330a285e621b9170c30a21cfea9ab32e2a2169" }
+revm-precompile = { git = "https://github.com/bluealloy/revm", rev = "33330a285e621b9170c30a21cfea9ab32e2a2169" }
+revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "33330a285e621b9170c30a21cfea9ab32e2a2169" }
+revm-state = { git = "https://github.com/bluealloy/revm", rev = "33330a285e621b9170c30a21cfea9ab32e2a2169" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,16 +68,16 @@ serde_json = "1"
 test-case = "3"
 
 [patch.crates-io]
-revm = { git = "https://github.com/bluealloy/revm", rev = "300efbf3e391e1796f5210cd4506508e385a55d2" }
-op-revm = { git = "https://github.com/bluealloy/revm", rev = "300efbf3e391e1796f5210cd4506508e385a55d2" }
-revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "300efbf3e391e1796f5210cd4506508e385a55d2" }
-revm-context = { git = "https://github.com/bluealloy/revm", rev = "300efbf3e391e1796f5210cd4506508e385a55d2" }
-revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "300efbf3e391e1796f5210cd4506508e385a55d2" }
-revm-database = { git = "https://github.com/bluealloy/revm", rev = "300efbf3e391e1796f5210cd4506508e385a55d2" }
-revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "300efbf3e391e1796f5210cd4506508e385a55d2" }
-revm-handler = { git = "https://github.com/bluealloy/revm", rev = "300efbf3e391e1796f5210cd4506508e385a55d2" }
-revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "300efbf3e391e1796f5210cd4506508e385a55d2" }
-revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "300efbf3e391e1796f5210cd4506508e385a55d2" }
-revm-precompile = { git = "https://github.com/bluealloy/revm", rev = "300efbf3e391e1796f5210cd4506508e385a55d2" }
-revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "300efbf3e391e1796f5210cd4506508e385a55d2" }
-revm-state = { git = "https://github.com/bluealloy/revm", rev = "300efbf3e391e1796f5210cd4506508e385a55d2" }
+revm = { git = "https://github.com/bluealloy/revm", rev = "f3b74d4ff0c6c88a09ca281323a100257fa61ebf" }
+op-revm = { git = "https://github.com/bluealloy/revm", rev = "f3b74d4ff0c6c88a09ca281323a100257fa61ebf" }
+revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "f3b74d4ff0c6c88a09ca281323a100257fa61ebf" }
+revm-context = { git = "https://github.com/bluealloy/revm", rev = "f3b74d4ff0c6c88a09ca281323a100257fa61ebf" }
+revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "f3b74d4ff0c6c88a09ca281323a100257fa61ebf" }
+revm-database = { git = "https://github.com/bluealloy/revm", rev = "f3b74d4ff0c6c88a09ca281323a100257fa61ebf" }
+revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "f3b74d4ff0c6c88a09ca281323a100257fa61ebf" }
+revm-handler = { git = "https://github.com/bluealloy/revm", rev = "f3b74d4ff0c6c88a09ca281323a100257fa61ebf" }
+revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "f3b74d4ff0c6c88a09ca281323a100257fa61ebf" }
+revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "f3b74d4ff0c6c88a09ca281323a100257fa61ebf" }
+revm-precompile = { git = "https://github.com/bluealloy/revm", rev = "f3b74d4ff0c6c88a09ca281323a100257fa61ebf" }
+revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "f3b74d4ff0c6c88a09ca281323a100257fa61ebf" }
+revm-state = { git = "https://github.com/bluealloy/revm", rev = "f3b74d4ff0c6c88a09ca281323a100257fa61ebf" }

--- a/crates/evm/src/env.rs
+++ b/crates/evm/src/env.rs
@@ -242,8 +242,8 @@ mod tests {
             evm_env.cfg_env.max_initcode_size(),
             revm::primitives::eip3860::MAX_INITCODE_SIZE
         );
-        // None respects the spec's default (u64::MAX for pre-Osaka specs)
-        assert_eq!(evm_env.cfg_env.tx_gas_limit_cap(), u64::MAX);
+        // None respects the spec's default (EIP-7825 cap for Osaka, which is now the default spec)
+        assert_eq!(evm_env.cfg_env.tx_gas_limit_cap(), revm::primitives::eip7825::TX_GAS_LIMIT_CAP);
     }
 
     #[test]

--- a/crates/evm/src/eth/env.rs
+++ b/crates/evm/src/eth/env.rs
@@ -91,6 +91,7 @@ impl EvmEnv<SpecId> {
             gas_limit: input.gas_limit,
             basefee: input.base_fee_per_gas,
             blob_excess_gas_and_price,
+            slot_num: 0,
         };
 
         Self::new(cfg_env, block_env)

--- a/crates/evm/src/op/env.rs
+++ b/crates/evm/src/op/env.rs
@@ -73,6 +73,7 @@ impl EvmEnv<OpSpecId> {
             basefee: input.base_fee_per_gas,
             // EIP-4844 excess blob gas of this block, introduced in Cancun
             blob_excess_gas_and_price,
+            slot_num: 0,
         };
 
         Self::new(cfg_env, block_env)

--- a/crates/evm/src/overrides.rs
+++ b/crates/evm/src/overrides.rs
@@ -57,7 +57,9 @@ impl<DB> OverrideBlockHashes for CacheDB<DB> {
 
 impl<DB> OverrideBlockHashes for State<DB> {
     fn override_block_hashes(&mut self, block_hashes: BTreeMap<u64, B256>) {
-        self.block_hashes.extend(block_hashes);
+        for (num, hash) in block_hashes {
+            self.block_hashes.insert(num, hash);
+        }
     }
 }
 

--- a/crates/op-evm/src/block/receipt_builder.rs
+++ b/crates/op-evm/src/block/receipt_builder.rs
@@ -18,6 +18,7 @@ pub trait OpReceiptBuilder: Debug {
     ///
     /// Note: this method should return `Err` if the transaction is a deposit transaction. In that
     /// case, the `build_deposit_receipt` method will be called.
+    #[allow(clippy::result_large_err)]
     fn build_receipt<'a, E: Evm>(
         &self,
         ctx: ReceiptBuilderCtx<'a, <Self::Transaction as TransactionEnvelope>::TxType, E>,


### PR DESCRIPTION
## Integration Summary

Staging integration for revm updates.

## Staged Crates

### revm
- **Commit**: `6aa06829d2caa2aa38606ed22b83354a7a7ff98e`
- **Changes**:
  - chore(scripts): update devnet test fixtures to bal@v5.1.0 devnet2 (#3392)
  - fix(journal): emit EIP-7708 log for selfdestructed accounts with remaining balance (#3394)
  - feat(statetest-types): add slot_number support (EIP-7843) (#3391)
  - fix(db): use self.storage() in storage_by_account_id to avoid cache bypass (#3385)
  - perf(state): avoid unnecessary clone, prealloc, and fix typo (#3387)
  - feat(database): add clear() to CacheState and TransitionState (#3390)
  - docs: remove GPL mention and update gmp feature comments (#3383)
  - deprecate: mark journal entry functions as deprecated (#3367)

## Fixes Made

- None required - clean integration