### PR TITLE
feat: add TxEnvironment and CfgEnvironment traits

### DIFF
--- a/crates/evm/src/env.rs
+++ b/crates/evm/src/env.rs
@@ -4,7 +4,7 @@ use core::fmt::Debug;
 
 use alloy_primitives::U256;
 use revm::{
-    context::{BlockEnv, CfgEnv},
+    context::{BlockEnv, CfgEnv, TxEnv},
     primitives::hardfork::SpecId,
 };
 
@@ -168,6 +168,39 @@ pub trait BlockEnvironment: revm::context::Block + Clone + Debug + Send + Sync +
 
 impl BlockEnvironment for BlockEnv {
     fn inner_mut(&mut self) -> &mut revm::context::BlockEnv {
+        self
+    }
+}
+
+/// Trait for types that can be used as a transaction environment.
+///
+/// Assumes that the type wraps an inner [`revm::context::TxEnv`].
+pub trait TxEnvironment:
+    revm::context::Transaction + Clone + Debug + Send + Sync + 'static
+{
+    /// Returns a mutable reference to the inner [`revm::context::TxEnv`].
+    fn tx_env_mut(&mut self) -> &mut revm::context::TxEnv;
+}
+
+impl TxEnvironment for TxEnv {
+    fn tx_env_mut(&mut self) -> &mut revm::context::TxEnv {
+        self
+    }
+}
+
+/// Trait for types that can be used as a configuration environment.
+///
+/// Assumes that the type wraps an inner [`revm::context::CfgEnv`].
+pub trait CfgEnvironment: revm::context::Cfg + Clone + Debug + Send + Sync + 'static {
+    /// Returns a mutable reference to the inner [`revm::context::CfgEnv`].
+    fn cfg_env_mut(&mut self) -> &mut CfgEnv<<Self as revm::context::Cfg>::Spec>;
+}
+
+impl<Spec> CfgEnvironment for CfgEnv<Spec>
+where
+    Self: revm::context::Cfg<Spec = Spec> + Clone + Debug + Send + Sync + 'static,
+{
+    fn cfg_env_mut(&mut self) -> &mut Self {
         self
     }
 }

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -15,7 +15,7 @@ pub use evm::{Database, Evm, EvmFactory};
 pub mod eth;
 pub use eth::{EthEvm, EthEvmFactory};
 pub mod env;
-pub use env::{EvmEnv, EvmLimitParams};
+pub use env::{CfgEnvironment, EvmEnv, EvmLimitParams, TxEnvironment};
 pub mod error;
 pub use error::*;
 pub mod tx;


### PR DESCRIPTION
Add TxEnvironment and CfgEnvironment traits mirroring the existing BlockEnvironment pattern, allowing network-specific transaction and config types to expose their inner revm types via mutable accessors.

- TxEnvironment: wraps revm::context::TxEnv with tx_env_mut()
- CfgEnvironment: wraps revm::context::CfgEnv with cfg_env_mut(), reusing the Spec associated type from the Cfg supertraitx