### PR TITLE
feat(evm): add TransactionEnvMut trait

### DIFF
--- a/crates/evm/src/env.rs
+++ b/crates/evm/src/env.rs
@@ -4,7 +4,8 @@ use core::fmt::Debug;
 
 use alloy_primitives::U256;
 use revm::{
-    context::{BlockEnv, CfgEnv},
+    context::{BlockEnv, CfgEnv, TxEnv},
+    context_interface::{transaction::AccessList, TransactionType},
     primitives::hardfork::SpecId,
 };
 
@@ -169,6 +170,59 @@ pub trait BlockEnvironment: revm::context::Block + Clone + Debug + Send + Sync +
 impl BlockEnvironment for BlockEnv {
     fn inner_mut(&mut self) -> &mut revm::context::BlockEnv {
         self
+    }
+}
+
+/// Abstraction over mutable transaction environment.
+///
+/// Provides setters for common transaction fields, complementing
+/// the read-only accessors on `revm::context::Transaction`.
+pub trait TransactionEnvMut:
+    revm::context::Transaction + Debug + Clone + Send + Sync + 'static
+{
+    /// Sets the gas limit.
+    fn set_gas_limit(&mut self, gas_limit: u64);
+
+    /// Sets the gas limit, returning `self`.
+    fn with_gas_limit(mut self, gas_limit: u64) -> Self {
+        self.set_gas_limit(gas_limit);
+        self
+    }
+
+    /// Sets the nonce.
+    fn set_nonce(&mut self, nonce: u64);
+
+    /// Sets the nonce, returning `self`.
+    fn with_nonce(mut self, nonce: u64) -> Self {
+        self.set_nonce(nonce);
+        self
+    }
+
+    /// Sets the access list.
+    fn set_access_list(&mut self, access_list: AccessList);
+
+    /// Sets the access list, returning `self`.
+    fn with_access_list(mut self, access_list: AccessList) -> Self {
+        self.set_access_list(access_list);
+        self
+    }
+}
+
+impl TransactionEnvMut for TxEnv {
+    fn set_gas_limit(&mut self, gas_limit: u64) {
+        self.gas_limit = gas_limit;
+    }
+
+    fn set_nonce(&mut self, nonce: u64) {
+        self.nonce = nonce;
+    }
+
+    fn set_access_list(&mut self, access_list: AccessList) {
+        self.access_list = access_list;
+
+        if self.tx_type == TransactionType::Legacy as u8 {
+            self.tx_type = TransactionType::Eip2930 as u8;
+        }
     }
 }
 

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -15,7 +15,7 @@ pub use evm::{Database, Evm, EvmFactory};
 pub mod eth;
 pub use eth::{EthEvm, EthEvmFactory};
 pub mod env;
-pub use env::{EvmEnv, EvmLimitParams};
+pub use env::{EvmEnv, EvmLimitParams, TransactionEnvMut};
 pub mod error;
 pub use error::*;
 pub mod tx;


### PR DESCRIPTION
Moves the `TransactionEnv` trait from reth into alloy-evm as `TransactionEnvMut`. Drops the redundant `nonce()` getter (already on the `Transaction` supertrait). Includes `TxEnv` impl only — `OpTransaction` impl omitted.

Prompted by: klkvr