### PR TITLE
fix: gate gas-without-refund block accounting behind Amsterdam fork

### DIFF
--- a/crates/evm/src/eth/block.rs
+++ b/crates/evm/src/eth/block.rs
@@ -60,8 +60,8 @@ pub struct EthBlockExecutor<'a, Evm, Spec, R: ReceiptBuilder> {
     /// Receipts of executed transactions.
     pub receipts: Vec<R::Receipt>,
 
-    /// Gas used by transactions in this block.
-    pub tx_gas_used: u64,
+    /// Cumulative gas used by transactions in this block.
+    pub cumulative_tx_gas_used: u64,
     /// Total gas used by transactions in this block.
     pub block_regular_gas_used: u64,
     /// State gas used by transactions in this block.
@@ -105,7 +105,7 @@ where
             receipts: Vec::with_capacity(tx_count_hint),
             block_regular_gas_used: 0,
             block_state_gas_used: 0,
-            tx_gas_used: 0,
+            cumulative_tx_gas_used: 0,
             blob_gas_used: 0,
             system_caller: SystemCaller::new(spec.clone()),
             spec,
@@ -164,7 +164,7 @@ where
         {
             self.max_block_gas_used()
         } else {
-            self.tx_gas_used
+            self.cumulative_tx_gas_used
         };
         let block_available_gas = self.evm.block().gas_limit() - block_gas_used;
 
@@ -205,7 +205,7 @@ where
         // append used gas used
         self.block_regular_gas_used += regular_gas_used;
         self.block_state_gas_used += state_gas_used;
-        self.tx_gas_used += tx_gas_used;
+        self.cumulative_tx_gas_used += tx_gas_used;
 
         // only determine cancun fields when active
         if self.spec.is_cancun_active_at_timestamp(self.evm.block().timestamp().saturating_to()) {
@@ -218,7 +218,7 @@ where
             evm: &self.evm,
             result,
             state: &state,
-            cumulative_gas_used: self.tx_gas_used,
+            cumulative_gas_used: self.cumulative_tx_gas_used,
         }));
 
         // Commit the state changes.
@@ -299,7 +299,7 @@ where
         {
             self.max_block_gas_used()
         } else {
-            self.tx_gas_used
+            self.cumulative_tx_gas_used
         };
 
         Ok((

--- a/crates/evm/src/eth/block.rs
+++ b/crates/evm/src/eth/block.rs
@@ -152,7 +152,21 @@ where
 
         // The sum of the transaction's gas limit, Tg, and the gas utilized in this block prior,
         // must be no greater than the block's gasLimit.
-        let block_available_gas = self.evm.block().gas_limit() - self.max_block_gas_used();
+        //
+        // Pre-Amsterdam: use tx_gas_used (gas after refunds) as cumulative gas, matching
+        // the original behavior where gas_used = spent - refunded.
+        //
+        // Amsterdam+: use max(block_regular_gas_used, block_state_gas_used) which tracks
+        // gas without refunds, as required by EIP-8037 dual-limit accounting.
+        let block_gas_used = if self
+            .spec
+            .is_amsterdam_active_at_timestamp(self.evm.block().timestamp().saturating_to())
+        {
+            self.max_block_gas_used()
+        } else {
+            self.tx_gas_used
+        };
+        let block_available_gas = self.evm.block().gas_limit() - block_gas_used;
 
         if tx.tx().gas_limit() > block_available_gas {
             return Err(BlockValidationError::TransactionGasLimitMoreThanAvailableBlockGas {
@@ -277,14 +291,23 @@ where
             })
         })?;
 
-        let max_gas_used = self.max_block_gas_used();
+        // Pre-Amsterdam: use tx_gas_used (with refunds) for the block gas total.
+        // Amsterdam+: use max(regular, state) gas without refunds (EIP-8037).
+        let gas_used = if self
+            .spec
+            .is_amsterdam_active_at_timestamp(self.evm.block().timestamp().saturating_to())
+        {
+            self.max_block_gas_used()
+        } else {
+            self.tx_gas_used
+        };
 
         Ok((
             self.evm,
             BlockExecutionResult {
                 receipts: self.receipts,
                 requests,
-                gas_used: max_gas_used,
+                gas_used,
                 blob_gas_used: self.blob_gas_used,
             },
         ))

--- a/crates/evm/src/precompiles.rs
+++ b/crates/evm/src/precompiles.rs
@@ -632,7 +632,7 @@ pub struct PrecompileErrorExt {
 impl PrecompileErrorExt {
     /// Creates a new [`PrecompileErrorExt`] from a [`PrecompileError`].
     #[inline]
-    pub fn from_precompile_error(error: PrecompileError, gas_tracker: GasTracker) -> Self {
+    pub const fn from_precompile_error(error: PrecompileError, gas_tracker: GasTracker) -> Self {
         Self { precompile_error: error, gas_tracker }
     }
 


### PR DESCRIPTION
Pre-Amsterdam, `block_available_gas` used `max_block_gas_used()` which tracks `block_regular_gas_used` (= gas_spent - state_gas_spent) **without subtracting refunds**. The original code used `gas_used` (= spent - refunded).

This caused cumulative block gas to exceed `gasLimit` on blocks with significant SSTORE refunds (~1.7M over 1024 txs), triggering false bad-block errors during pipeline sync. Observed on block 24742820 with reth tip1016:

```
transaction gas limit 59485 is more than blocks available gas 55128
```

Gates the EIP-8037 dual-limit gas accounting (without refunds) behind `is_amsterdam_active_at_timestamp`. Pre-Amsterdam blocks now use `tx_gas_used` (with refunds), matching the original behavior.

Prompted by: dragan