### PR TITLE
Enable system call to be traced by inspector

### DIFF
--- a/crates/evm/src/eth/mod.rs
+++ b/crates/evm/src/eth/mod.rs
@@ -16,7 +16,8 @@ use revm::{
     interpreter::{interpreter::EthInterpreter, InterpreterResult},
     precompile::{PrecompileSpecId, Precompiles},
     primitives::hardfork::SpecId,
-    Context, ExecuteEvm, InspectEvm, Inspector, MainBuilder, MainContext, SystemCallEvm,
+    Context, ExecuteEvm, InspectEvm, InspectSystemCallEvm, Inspector, MainBuilder, MainContext,
+    SystemCallEvm,
 };
 
 mod block;
@@ -232,7 +233,12 @@ where
         contract: Address,
         data: Bytes,
     ) -> Result<ResultAndState<Self::HaltReason>, Self::Error> {
-        self.inner.system_call_with_caller(caller, contract, data)
+        if self.inspect {
+            self.inner
+                .inspect_system_call_with_caller(caller, contract, data)
+        } else {
+            self.inner.system_call_with_caller(caller, contract, data)
+        }
     }
 
     fn finish(self) -> (Self::DB, EvmEnv<Self::Spec>) {


### PR DESCRIPTION
## Motivation

When using ExEx to replay a full block including the pre/post execution steps, system calls weren't inspected before if inspector was enabled.

## Solution

Just like `transact_raw` does, if the `EthEvm` is in inspect mode, `transact_system_call` now check if `self.inspect` is set and call the inspect variant of 
`inspect_system_call_with_caller`.

### Open Questions

One thing I'm unusure of the impact is about other inspector out there, would they be affected?

Maybe `self.inspect` could be switch off before `transact_system_call` is called in the current code and restored after to keep current behavior.

## PR Checklist

Waiting on initial feedback.

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
