### PR TITLE
docs: improve state hook source docs and add Other variants

### DIFF
--- a/crates/evm/src/block/state_hook.rs
+++ b/crates/evm/src/block/state_hook.rs
@@ -17,26 +17,38 @@ pub enum StateChangeSource {
     PostBlock(StateChangePostBlockSource),
 }
 
-/// Source of the pre-block state change
+/// Source of a pre-block state change caused by an EVM system call that executes before
+/// transaction processing begins.
+///
+/// These system calls are protocol-level EVM invocations that update specific system contracts
+/// at the start of each block, prior to any user transactions.
 #[derive(Debug, Clone, Copy)]
 pub enum StateChangePreBlockSource {
-    /// EIP-2935 blockhashes contract
+    /// EIP-2935: stores parent block hashes in a system contract for in-EVM access.
     BlockHashesContract,
-    /// EIP-4788 beacon root contract
+    /// EIP-4788: stores the parent beacon block root in a system contract, making consensus layer
+    /// data available to smart contracts.
     BeaconRootContract,
-    /// EIP-7002 withdrawal requests contract
+    /// EIP-7002: triggers the withdrawal requests contract to process any queued validator
+    /// withdrawal requests.
     WithdrawalRequestsContract,
+    /// A custom pre-block state change not covered by the standard variants.
+    Other(&'static str),
 }
 
-/// Source of the post-block state change
+/// Source of a post-block state change caused by a system call or balance modification that
+/// executes after all transactions in the block have been processed.
 #[derive(Debug, Clone, Copy)]
 pub enum StateChangePostBlockSource {
-    /// Balance increments from block rewards and withdrawals
+    /// Balance increments applied for block rewards (e.g. beacon withdrawals, ommer rewards).
     BalanceIncrements,
-    /// EIP-7002 withdrawal requests contract
+    /// EIP-7002: processes withdrawal requests contract after block execution.
     WithdrawalRequestsContract,
-    /// EIP-7251 consolidation requests contract
+    /// EIP-7251: processes the consolidation requests contract to handle queued validator
+    /// consolidations.
     ConsolidationRequestsContract,
+    /// A custom post-block state change not covered by the standard variants.
+    Other(&'static str),
 }
 
 impl<F> OnStateHook for F


### PR DESCRIPTION
Improves documentation for `StateChangePreBlockSource` and `StateChangePostBlockSource` to better describe the EVM system calls each variant represents. Adds an `Other(&'static str)` variant to `StateChangePostBlockSource` for custom post-block state changes, matching the existing pattern in `StateChangePreBlockSource`.