### PR TITLE
chore: use  reservoir for from_precompile_output

### DIFF
--- a/crates/evm/src/precompiles.rs
+++ b/crates/evm/src/precompiles.rs
@@ -986,10 +986,14 @@ impl From<(PrecompileId, PrecompileFn)> for DynPrecompile {
     fn from((id, f): (PrecompileId, PrecompileFn)) -> Self {
         let p = move |input: PrecompileInput<'_>| -> PrecompileResultExt {
             match f(input.data, input.gas) {
-                Ok(output) => Ok(PrecompileOutputExt::from_precompile_output(output, input.gas, 0)),
+                Ok(output) => Ok(PrecompileOutputExt::from_precompile_output(
+                    output,
+                    input.gas,
+                    input.reservoir,
+                )),
                 Err(error) => Err(PrecompileErrorExt::from_precompile_error(
                     error,
-                    GasTracker::new(input.gas, 0, 0),
+                    GasTracker::new(input.gas, 0, input.reservoir),
                 )),
             }
         };


### PR DESCRIPTION
passed `input.reservoir` to `from_precompile_output` and `from_precompile_error` in order to fix `tests/osaka/eip7883_modexp_gas_increase/test_modexp_thresholds.py::test_modexp_variable_gas_cost_exceed_tx_gas_cap[fork_Amsterdam-blockchain_test_engine_from_state_test-Z16-gas-cap-test]`


cc: @rakita 