### PR TITLE
chore: bump alloy to 2.0.0-rc.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,22 +70,22 @@ serde_json = "1"
 test-case = "3"
 
 [patch.crates-io]
-alloy-eips = { git = "https://github.com/alloy-rs/alloy", rev = "4b68a95f" }
-alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "4b68a95f" }
-alloy-rpc-types-eth = { git = "https://github.com/alloy-rs/alloy", rev = "4b68a95f" }
-alloy-rpc-types-engine = { git = "https://github.com/alloy-rs/alloy", rev = "4b68a95f" }
+alloy-eips = { git = "https://github.com/alloy-rs/alloy", rev = "bf8a385" }
+alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "bf8a385" }
+alloy-rpc-types-eth = { git = "https://github.com/alloy-rs/alloy", rev = "bf8a385" }
+alloy-rpc-types-engine = { git = "https://github.com/alloy-rs/alloy", rev = "bf8a385" }
 
-alloy-json-rpc = { git = "https://github.com/alloy-rs/alloy", rev = "4b68a95f" }
-alloy-network = { git = "https://github.com/alloy-rs/alloy", rev = "4b68a95f" }
-alloy-network-primitives = { git = "https://github.com/alloy-rs/alloy", rev = "4b68a95f" }
-alloy-provider = { git = "https://github.com/alloy-rs/alloy", rev = "4b68a95f" }
-alloy-rpc-client = { git = "https://github.com/alloy-rs/alloy", rev = "4b68a95f" }
-alloy-rpc-types-debug = { git = "https://github.com/alloy-rs/alloy", rev = "4b68a95f" }
-alloy-rpc-types-trace = { git = "https://github.com/alloy-rs/alloy", rev = "4b68a95f" }
-alloy-serde = { git = "https://github.com/alloy-rs/alloy", rev = "4b68a95f" }
-alloy-signer = { git = "https://github.com/alloy-rs/alloy", rev = "4b68a95f" }
-alloy-transport = { git = "https://github.com/alloy-rs/alloy", rev = "4b68a95f" }
-alloy-transport-http = { git = "https://github.com/alloy-rs/alloy", rev = "4b68a95f" }
+alloy-json-rpc = { git = "https://github.com/alloy-rs/alloy", rev = "bf8a385" }
+alloy-network = { git = "https://github.com/alloy-rs/alloy", rev = "bf8a385" }
+alloy-network-primitives = { git = "https://github.com/alloy-rs/alloy", rev = "bf8a385" }
+alloy-provider = { git = "https://github.com/alloy-rs/alloy", rev = "bf8a385" }
+alloy-rpc-client = { git = "https://github.com/alloy-rs/alloy", rev = "bf8a385" }
+alloy-rpc-types-debug = { git = "https://github.com/alloy-rs/alloy", rev = "bf8a385" }
+alloy-rpc-types-trace = { git = "https://github.com/alloy-rs/alloy", rev = "bf8a385" }
+alloy-serde = { git = "https://github.com/alloy-rs/alloy", rev = "bf8a385" }
+alloy-signer = { git = "https://github.com/alloy-rs/alloy", rev = "bf8a385" }
+alloy-transport = { git = "https://github.com/alloy-rs/alloy", rev = "bf8a385" }
+alloy-transport-http = { git = "https://github.com/alloy-rs/alloy", rev = "bf8a385" }
 
 op-alloy = { git = "https://github.com/stevencartavia/optimism", rev = "f635f023c6cf5cb2a7c4fd43f589c0efda83c8e3" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,5 +87,5 @@ alloy-signer = { git = "https://github.com/alloy-rs/alloy", rev = "4b68a95f" }
 alloy-transport = { git = "https://github.com/alloy-rs/alloy", rev = "4b68a95f" }
 alloy-transport-http = { git = "https://github.com/alloy-rs/alloy", rev = "4b68a95f" }
 
-op-alloy = { git = "https://github.com/ethereum-optimism/optimism", rev = "1ebf2dc0d2fd86137d97b485c7994e7404744c87" }
+op-alloy = { git = "https://github.com/stevencartavia/optimism", rev = "f635f023c6cf5cb2a7c4fd43f589c0efda83c8e3" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,13 +40,13 @@ alloy-evm = { version = "0.29.2", path = "crates/evm", default-features = false 
 # alloy
 alloy-eip2124 = { version = "0.2", default-features = false }
 alloy-chains = { version = "0.2.0", default-features = false }
-alloy-eips = { version = "2.0.0-rc.0", default-features = false }
-alloy-consensus = { version = "2.0.0-rc.0", default-features = false }
+alloy-eips = { version = "2.0.0-rc.1", default-features = false }
+alloy-consensus = { version = "2.0.0-rc.1", default-features = false }
 alloy-primitives = { version = "1.0.0", default-features = false }
 alloy-sol-types = { version = "1.0.0", default-features = false }
 alloy-hardforks = { version = "0.4.7" }
-alloy-rpc-types-eth = { version = "2.0.0-rc.0", default-features = false }
-alloy-rpc-types-engine = { version = "2.0.0-rc.0", default-features = false }
+alloy-rpc-types-eth = { version = "2.0.0-rc.1", default-features = false }
+alloy-rpc-types-engine = { version = "2.0.0-rc.1", default-features = false }
 
 # op-alloy
 alloy-op-hardforks = { version = "0.4.7" }
@@ -70,22 +70,22 @@ serde_json = "1"
 test-case = "3"
 
 [patch.crates-io]
-alloy-eips = { git = "https://github.com/alloy-rs/alloy", rev = "100a3325ac4d624f3eb0bd404125750e76edf8ca" }
-alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "100a3325ac4d624f3eb0bd404125750e76edf8ca" }
-alloy-rpc-types-eth = { git = "https://github.com/alloy-rs/alloy", rev = "100a3325ac4d624f3eb0bd404125750e76edf8ca" }
-alloy-rpc-types-engine = { git = "https://github.com/alloy-rs/alloy", rev = "100a3325ac4d624f3eb0bd404125750e76edf8ca" }
+alloy-eips = { git = "https://github.com/alloy-rs/alloy", rev = "4b68a95f" }
+alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "4b68a95f" }
+alloy-rpc-types-eth = { git = "https://github.com/alloy-rs/alloy", rev = "4b68a95f" }
+alloy-rpc-types-engine = { git = "https://github.com/alloy-rs/alloy", rev = "4b68a95f" }
 
-alloy-json-rpc = { git = "https://github.com/alloy-rs/alloy", rev = "100a3325ac4d624f3eb0bd404125750e76edf8ca" }
-alloy-network = { git = "https://github.com/alloy-rs/alloy", rev = "100a3325ac4d624f3eb0bd404125750e76edf8ca" }
-alloy-network-primitives = { git = "https://github.com/alloy-rs/alloy", rev = "100a3325ac4d624f3eb0bd404125750e76edf8ca" }
-alloy-provider = { git = "https://github.com/alloy-rs/alloy", rev = "100a3325ac4d624f3eb0bd404125750e76edf8ca" }
-alloy-rpc-client = { git = "https://github.com/alloy-rs/alloy", rev = "100a3325ac4d624f3eb0bd404125750e76edf8ca" }
-alloy-rpc-types-debug = { git = "https://github.com/alloy-rs/alloy", rev = "100a3325ac4d624f3eb0bd404125750e76edf8ca" }
-alloy-rpc-types-trace = { git = "https://github.com/alloy-rs/alloy", rev = "100a3325ac4d624f3eb0bd404125750e76edf8ca" }
-alloy-serde = { git = "https://github.com/alloy-rs/alloy", rev = "100a3325ac4d624f3eb0bd404125750e76edf8ca" }
-alloy-signer = { git = "https://github.com/alloy-rs/alloy", rev = "100a3325ac4d624f3eb0bd404125750e76edf8ca" }
-alloy-transport = { git = "https://github.com/alloy-rs/alloy", rev = "100a3325ac4d624f3eb0bd404125750e76edf8ca" }
-alloy-transport-http = { git = "https://github.com/alloy-rs/alloy", rev = "100a3325ac4d624f3eb0bd404125750e76edf8ca" }
+alloy-json-rpc = { git = "https://github.com/alloy-rs/alloy", rev = "4b68a95f" }
+alloy-network = { git = "https://github.com/alloy-rs/alloy", rev = "4b68a95f" }
+alloy-network-primitives = { git = "https://github.com/alloy-rs/alloy", rev = "4b68a95f" }
+alloy-provider = { git = "https://github.com/alloy-rs/alloy", rev = "4b68a95f" }
+alloy-rpc-client = { git = "https://github.com/alloy-rs/alloy", rev = "4b68a95f" }
+alloy-rpc-types-debug = { git = "https://github.com/alloy-rs/alloy", rev = "4b68a95f" }
+alloy-rpc-types-trace = { git = "https://github.com/alloy-rs/alloy", rev = "4b68a95f" }
+alloy-serde = { git = "https://github.com/alloy-rs/alloy", rev = "4b68a95f" }
+alloy-signer = { git = "https://github.com/alloy-rs/alloy", rev = "4b68a95f" }
+alloy-transport = { git = "https://github.com/alloy-rs/alloy", rev = "4b68a95f" }
+alloy-transport-http = { git = "https://github.com/alloy-rs/alloy", rev = "4b68a95f" }
 
 op-alloy = { git = "https://github.com/ethereum-optimism/optimism", rev = "1ebf2dc0d2fd86137d97b485c7994e7404744c87" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.29.2"
+version = "0.30.0"
 edition = "2021"
 rust-version = "1.91"
 authors = ["Alloy Contributors"]
@@ -35,7 +35,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [workspace.dependencies]
-alloy-evm = { version = "0.29.2", path = "crates/evm", default-features = false }
+alloy-evm = { version = "0.30.0", path = "crates/evm", default-features = false }
 
 # alloy
 alloy-eip2124 = { version = "0.2", default-features = false }

--- a/crates/evm/src/env.rs
+++ b/crates/evm/src/env.rs
@@ -4,7 +4,8 @@ use core::fmt::Debug;
 
 use alloy_primitives::U256;
 use revm::{
-    context::{BlockEnv, CfgEnv},
+    context::{BlockEnv, CfgEnv, TxEnv},
+    context_interface::{transaction::AccessList, TransactionType},
     primitives::hardfork::SpecId,
 };
 
@@ -169,6 +170,59 @@ pub trait BlockEnvironment: revm::context::Block + Clone + Debug + Send + Sync +
 impl BlockEnvironment for BlockEnv {
     fn inner_mut(&mut self) -> &mut revm::context::BlockEnv {
         self
+    }
+}
+
+/// Abstraction over mutable transaction environment.
+///
+/// Provides setters for common transaction fields, complementing
+/// the read-only accessors on `revm::context::Transaction`.
+pub trait TransactionEnvMut:
+    revm::context::Transaction + Debug + Clone + Send + Sync + 'static
+{
+    /// Sets the gas limit.
+    fn set_gas_limit(&mut self, gas_limit: u64);
+
+    /// Sets the gas limit, returning `self`.
+    fn with_gas_limit(mut self, gas_limit: u64) -> Self {
+        self.set_gas_limit(gas_limit);
+        self
+    }
+
+    /// Sets the nonce.
+    fn set_nonce(&mut self, nonce: u64);
+
+    /// Sets the nonce, returning `self`.
+    fn with_nonce(mut self, nonce: u64) -> Self {
+        self.set_nonce(nonce);
+        self
+    }
+
+    /// Sets the access list.
+    fn set_access_list(&mut self, access_list: AccessList);
+
+    /// Sets the access list, returning `self`.
+    fn with_access_list(mut self, access_list: AccessList) -> Self {
+        self.set_access_list(access_list);
+        self
+    }
+}
+
+impl TransactionEnvMut for TxEnv {
+    fn set_gas_limit(&mut self, gas_limit: u64) {
+        self.gas_limit = gas_limit;
+    }
+
+    fn set_nonce(&mut self, nonce: u64) {
+        self.nonce = nonce;
+    }
+
+    fn set_access_list(&mut self, access_list: AccessList) {
+        self.access_list = access_list;
+
+        if self.tx_type == TransactionType::Legacy as u8 {
+            self.tx_type = TransactionType::Eip2930 as u8;
+        }
     }
 }
 

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -15,7 +15,7 @@ pub use evm::{Database, Evm, EvmFactory};
 pub mod eth;
 pub use eth::{EthEvm, EthEvmFactory};
 pub mod env;
-pub use env::{EvmEnv, EvmLimitParams};
+pub use env::{EvmEnv, EvmLimitParams, TransactionEnvMut};
 pub mod error;
 pub use error::*;
 pub mod tx;


### PR DESCRIPTION
Bump alloy dependency versions from `2.0.0-rc.0` to `2.0.0-rc.1` and update all `[patch.crates-io]` revs (15 entries) to alloy `release/2.0.0-rc.1` HEAD (`4b68a95f`).