### PR TITLE
chore: bump alloy to 2.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,13 +40,13 @@ alloy-evm = { version = "0.30.0", path = "crates/evm", default-features = false 
 # alloy
 alloy-eip2124 = { version = "0.2", default-features = false }
 alloy-chains = { version = "0.2.0", default-features = false }
-alloy-eips = { version = "1.5.2", default-features = false }
-alloy-consensus = { version = "1.5.2", default-features = false }
+alloy-eips = { version = "2.0.0", default-features = false }
+alloy-consensus = { version = "2.0.0", default-features = false }
 alloy-primitives = { version = "1.0.0", default-features = false }
 alloy-sol-types = { version = "1.0.0", default-features = false }
 alloy-hardforks = { version = "0.4.7" }
-alloy-rpc-types-eth = { version = "1.5.2", default-features = false }
-alloy-rpc-types-engine = { version = "1.5.2", default-features = false }
+alloy-rpc-types-eth = { version = "2.0.0", default-features = false }
+alloy-rpc-types-engine = { version = "2.0.0", default-features = false }
 
 # revm
 revm = { version = "36.0.0", default-features = false }


### PR DESCRIPTION
Bump alloy dependencies to the released 2.0.0 versions. No code changes required.