### PR TITLE
fix: enforce state-gas budget against tx gas limit

### DIFF
--- a/crates/evm/src/block/error.rs
+++ b/crates/evm/src/block/error.rs
@@ -29,6 +29,16 @@ pub enum BlockValidationError {
         /// The available block gas
         block_available_gas: u64,
     },
+    /// Error when transaction gas limit exceeds available block state gas (EIP-8037).
+    #[error(
+        "transaction gas limit {transaction_gas_limit} is more than blocks available state gas {block_available_state_gas}"
+    )]
+    TransactionGasLimitMoreThanAvailableBlockStateGas {
+        /// The transaction's gas limit
+        transaction_gas_limit: u64,
+        /// The available block state gas
+        block_available_state_gas: u64,
+    },
     /// Error for EIP-4788 when parent beacon block root is missing
     #[error("EIP-4788 parent beacon block root missing for active Cancun block")]
     MissingParentBeaconBlockRoot,

--- a/crates/evm/src/eth/block.rs
+++ b/crates/evm/src/eth/block.rs
@@ -187,6 +187,23 @@ where
             .into());
         }
 
+        // Amsterdam+: state gas is not bounded by `tx_gas_limit_cap`, so a transaction can
+        // consume up to its full `gas_limit` worth of state gas. The block's state-gas
+        // reservoir is bounded by `block.gas_limit`, so the uncapped `tx.gas_limit` must
+        // also fit in the remaining state-gas budget — otherwise the block cannot stay
+        // within its overall gas limit.
+        if self.evm.cfg_env().enable_amsterdam_eip8037 {
+            let block_state_available_gas =
+                self.evm.block().gas_limit() - self.block_state_gas_used;
+            if tx.tx().gas_limit() > block_state_available_gas {
+                return Err(BlockValidationError::TransactionGasLimitMoreThanAvailableBlockGas {
+                    transaction_gas_limit: tx.tx().gas_limit(),
+                    block_available_gas: block_state_available_gas,
+                }
+                .into());
+            }
+        }
+
         // Execute transaction and return the result
         let result = self.evm.transact(tx_env).map_err(|err| {
             let hash = tx.tx().trie_hash();

--- a/crates/evm/src/eth/block.rs
+++ b/crates/evm/src/eth/block.rs
@@ -193,14 +193,16 @@ where
         // also fit in the remaining state-gas budget — otherwise the block cannot stay
         // within its overall gas limit.
         if self.evm.cfg_env().enable_amsterdam_eip8037 {
-            let block_state_available_gas =
+            let block_available_state_gas =
                 self.evm.block().gas_limit() - self.block_state_gas_used;
-            if tx.tx().gas_limit() > block_state_available_gas {
-                return Err(BlockValidationError::TransactionGasLimitMoreThanAvailableBlockGas {
-                    transaction_gas_limit: tx.tx().gas_limit(),
-                    block_available_gas: block_state_available_gas,
-                }
-                .into());
+            if tx.tx().gas_limit() > block_available_state_gas {
+                return Err(
+                    BlockValidationError::TransactionGasLimitMoreThanAvailableBlockStateGas {
+                        transaction_gas_limit: tx.tx().gas_limit(),
+                        block_available_state_gas,
+                    }
+                    .into(),
+                );
             }
         }
 


### PR DESCRIPTION
## Summary
- Add a second per-tx gas-limit check in the Ethereum block executor: on Amsterdam+ blocks, the uncapped `tx.gas_limit` must also fit in the remaining state-gas budget (`block.gas_limit - block_state_gas_used`). Without this, state gas could push the block past its overall gas limit, since `tx_gas_limit_cap` does not bound state gas.
- Introduce a distinct `BlockValidationError::TransactionGasLimitMoreThanAvailableBlockStateGas` variant so callers can tell a state-gas overflow apart from a regular-gas overflow.

## Test plan
- [ ] `cargo check -p alloy-evm` (passes locally)
- [ ] Add an integration test that submits a tx whose `gas_limit` exceeds the remaining state-gas budget and asserts the new error variant is returned
- [ ] Verify pre-Amsterdam blocks are unaffected (new branch is gated on `enable_amsterdam_eip8037`)