### PR TITLE
refactor(block): expose executor tx result type

### DIFF
--- a/crates/evm/src/block/mod.rs
+++ b/crates/evm/src/block/mod.rs
@@ -449,6 +449,7 @@ where
         Evm = <F::EvmFactory as EvmFactory>::Evm<DB, I>,
         Transaction = F::Transaction,
         Receipt = F::Receipt,
+        Result = F::TxExecutionResult,
     >,
     DB: StateDB + 'a,
     I: Inspector<<F::EvmFactory as EvmFactory>::Context<DB>> + 'a,
@@ -464,6 +465,7 @@ where
         Evm = <F::EvmFactory as EvmFactory>::Evm<DB, I>,
         Transaction = F::Transaction,
         Receipt = F::Receipt,
+        Result = F::TxExecutionResult,
     >,
 {
 }
@@ -497,6 +499,18 @@ where
 pub trait BlockExecutorFactory: 'static {
     /// The EVM factory used by the executor.
     type EvmFactory: EvmFactory;
+
+    /// Result type produced by the executor for each transaction.
+    ///
+    /// This is the concrete [`BlockExecutor::Result`] type returned by executors created from this
+    /// factory. It captures the raw EVM execution output before it is committed into block state
+    /// and converted into a receipt.
+    ///
+    /// Exposing this type on the factory allows generic callers that only know the
+    /// [`BlockExecutorFactory`] to name the per-transaction execution result produced by its
+    /// executors. The result's halt reason must match the halt reason used by the configured
+    /// [`EvmFactory`].
+    type TxExecutionResult: TxResult<HaltReason = <Self::EvmFactory as EvmFactory>::HaltReason>;
 
     /// Context required for block execution beyond what the EVM provides (e.g.
     /// [`EvmEnv`](crate::EvmEnv))

--- a/crates/evm/src/eth/block.rs
+++ b/crates/evm/src/eth/block.rs
@@ -393,6 +393,10 @@ where
     type ExecutionCtx<'a> = EthBlockExecutionCtx<'a>;
     type Transaction = R::Transaction;
     type Receipt = R::Receipt;
+    type TxExecutionResult = EthTxResult<
+        <EvmF as EvmFactory>::HaltReason,
+        <R::Transaction as TransactionEnvelope>::TxType,
+    >;
 
     fn evm_factory(&self) -> &Self::EvmFactory {
         &self.evm_factory


### PR DESCRIPTION
Epose transaction execution result type on `BlockExecutorFactory`.

Before this, `BlockExecutorFor` was fixing executor EVM, transaction and
receipt types, but not `BlockExecutor::Result`. Because of that generic
code could not name tx execution result type from factory-created
executor.

Now `BlockExecutorFor` also constrains `BlockExecutor::Result` via
factory associated type, so downstream code can use this type
without adding extra `BlockExecutor<Result = ...>` bound.

This is a part of type plumbing required for parallel execution, see https://github.com/paradigmxyz/reth/pull/23759

> [!NOTE]
> This is based off the latest released version, not main.
