### PR TITLE
feat(bal-devnet-4): integrate revm (rev 3ed3bdfe)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,15 +63,15 @@ serde_json = "1"
 test-case = "3"
 
 [patch.crates-io]
-revm = { git = "https://github.com/bluealloy/revm", rev = "7a2de5a4afe155f563120a02bfd96e64fa1bb158" }
-revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "7a2de5a4afe155f563120a02bfd96e64fa1bb158" }
-revm-context = { git = "https://github.com/bluealloy/revm", rev = "7a2de5a4afe155f563120a02bfd96e64fa1bb158" }
-revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "7a2de5a4afe155f563120a02bfd96e64fa1bb158" }
-revm-database = { git = "https://github.com/bluealloy/revm", rev = "7a2de5a4afe155f563120a02bfd96e64fa1bb158" }
-revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "7a2de5a4afe155f563120a02bfd96e64fa1bb158" }
-revm-handler = { git = "https://github.com/bluealloy/revm", rev = "7a2de5a4afe155f563120a02bfd96e64fa1bb158" }
-revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "7a2de5a4afe155f563120a02bfd96e64fa1bb158" }
-revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "7a2de5a4afe155f563120a02bfd96e64fa1bb158" }
-revm-precompile = { git = "https://github.com/bluealloy/revm", rev = "7a2de5a4afe155f563120a02bfd96e64fa1bb158" }
-revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "7a2de5a4afe155f563120a02bfd96e64fa1bb158" }
-revm-state = { git = "https://github.com/bluealloy/revm", rev = "7a2de5a4afe155f563120a02bfd96e64fa1bb158" }
+revm = { git = "https://github.com/bluealloy/revm", rev = "fe2549d85fb9e201e7b629f8b47bcca46d49aa1d" }
+revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "fe2549d85fb9e201e7b629f8b47bcca46d49aa1d" }
+revm-context = { git = "https://github.com/bluealloy/revm", rev = "fe2549d85fb9e201e7b629f8b47bcca46d49aa1d" }
+revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "fe2549d85fb9e201e7b629f8b47bcca46d49aa1d" }
+revm-database = { git = "https://github.com/bluealloy/revm", rev = "fe2549d85fb9e201e7b629f8b47bcca46d49aa1d" }
+revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "fe2549d85fb9e201e7b629f8b47bcca46d49aa1d" }
+revm-handler = { git = "https://github.com/bluealloy/revm", rev = "fe2549d85fb9e201e7b629f8b47bcca46d49aa1d" }
+revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "fe2549d85fb9e201e7b629f8b47bcca46d49aa1d" }
+revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "fe2549d85fb9e201e7b629f8b47bcca46d49aa1d" }
+revm-precompile = { git = "https://github.com/bluealloy/revm", rev = "fe2549d85fb9e201e7b629f8b47bcca46d49aa1d" }
+revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "fe2549d85fb9e201e7b629f8b47bcca46d49aa1d" }
+revm-state = { git = "https://github.com/bluealloy/revm", rev = "fe2549d85fb9e201e7b629f8b47bcca46d49aa1d" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ alloy-rpc-types-eth = { version = "2.0.0", default-features = false }
 alloy-rpc-types-engine = { version = "2.0.0", default-features = false }
 
 # revm
-revm = { version = "38.0.0", default-features = false }
+revm = { version = "37.0.0", default-features = false }
 
 # tracing
 tracing = { version = "0.1", default-features = false }
@@ -61,3 +61,17 @@ serde = { version = "1", default-features = false, features = ["derive"] }
 thiserror = { version = "2.0.0", default-features = false }
 serde_json = "1"
 test-case = "3"
+
+[patch.crates-io]
+revm = { git = "https://github.com/bluealloy/revm", rev = "7a2de5a4afe155f563120a02bfd96e64fa1bb158" }
+revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "7a2de5a4afe155f563120a02bfd96e64fa1bb158" }
+revm-context = { git = "https://github.com/bluealloy/revm", rev = "7a2de5a4afe155f563120a02bfd96e64fa1bb158" }
+revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "7a2de5a4afe155f563120a02bfd96e64fa1bb158" }
+revm-database = { git = "https://github.com/bluealloy/revm", rev = "7a2de5a4afe155f563120a02bfd96e64fa1bb158" }
+revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "7a2de5a4afe155f563120a02bfd96e64fa1bb158" }
+revm-handler = { git = "https://github.com/bluealloy/revm", rev = "7a2de5a4afe155f563120a02bfd96e64fa1bb158" }
+revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "7a2de5a4afe155f563120a02bfd96e64fa1bb158" }
+revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "7a2de5a4afe155f563120a02bfd96e64fa1bb158" }
+revm-precompile = { git = "https://github.com/bluealloy/revm", rev = "7a2de5a4afe155f563120a02bfd96e64fa1bb158" }
+revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "7a2de5a4afe155f563120a02bfd96e64fa1bb158" }
+revm-state = { git = "https://github.com/bluealloy/revm", rev = "7a2de5a4afe155f563120a02bfd96e64fa1bb158" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ alloy-rpc-types-eth = { version = "2.0.0", default-features = false }
 alloy-rpc-types-engine = { version = "2.0.0", default-features = false }
 
 # revm
-revm = { version = "37.0.0", default-features = false }
+revm = { version = "38.0.0", default-features = false }
 
 # tracing
 tracing = { version = "0.1", default-features = false }
@@ -63,15 +63,15 @@ serde_json = "1"
 test-case = "3"
 
 [patch.crates-io]
-revm = { git = "https://github.com/bluealloy/revm", rev = "fe2549d85fb9e201e7b629f8b47bcca46d49aa1d" }
-revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "fe2549d85fb9e201e7b629f8b47bcca46d49aa1d" }
-revm-context = { git = "https://github.com/bluealloy/revm", rev = "fe2549d85fb9e201e7b629f8b47bcca46d49aa1d" }
-revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "fe2549d85fb9e201e7b629f8b47bcca46d49aa1d" }
-revm-database = { git = "https://github.com/bluealloy/revm", rev = "fe2549d85fb9e201e7b629f8b47bcca46d49aa1d" }
-revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "fe2549d85fb9e201e7b629f8b47bcca46d49aa1d" }
-revm-handler = { git = "https://github.com/bluealloy/revm", rev = "fe2549d85fb9e201e7b629f8b47bcca46d49aa1d" }
-revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "fe2549d85fb9e201e7b629f8b47bcca46d49aa1d" }
-revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "fe2549d85fb9e201e7b629f8b47bcca46d49aa1d" }
-revm-precompile = { git = "https://github.com/bluealloy/revm", rev = "fe2549d85fb9e201e7b629f8b47bcca46d49aa1d" }
-revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "fe2549d85fb9e201e7b629f8b47bcca46d49aa1d" }
-revm-state = { git = "https://github.com/bluealloy/revm", rev = "fe2549d85fb9e201e7b629f8b47bcca46d49aa1d" }
+revm = { git = "https://github.com/bluealloy/revm", rev = "3ed3bdfed9ad6e5ba37f4e1f015436ab89ca98be" }
+revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "3ed3bdfed9ad6e5ba37f4e1f015436ab89ca98be" }
+revm-context = { git = "https://github.com/bluealloy/revm", rev = "3ed3bdfed9ad6e5ba37f4e1f015436ab89ca98be" }
+revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "3ed3bdfed9ad6e5ba37f4e1f015436ab89ca98be" }
+revm-database = { git = "https://github.com/bluealloy/revm", rev = "3ed3bdfed9ad6e5ba37f4e1f015436ab89ca98be" }
+revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "3ed3bdfed9ad6e5ba37f4e1f015436ab89ca98be" }
+revm-handler = { git = "https://github.com/bluealloy/revm", rev = "3ed3bdfed9ad6e5ba37f4e1f015436ab89ca98be" }
+revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "3ed3bdfed9ad6e5ba37f4e1f015436ab89ca98be" }
+revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "3ed3bdfed9ad6e5ba37f4e1f015436ab89ca98be" }
+revm-precompile = { git = "https://github.com/bluealloy/revm", rev = "3ed3bdfed9ad6e5ba37f4e1f015436ab89ca98be" }
+revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "3ed3bdfed9ad6e5ba37f4e1f015436ab89ca98be" }
+revm-state = { git = "https://github.com/bluealloy/revm", rev = "3ed3bdfed9ad6e5ba37f4e1f015436ab89ca98be" }

--- a/crates/evm/src/block/state_changes.rs
+++ b/crates/evm/src/block/state_changes.rs
@@ -1,7 +1,6 @@
 //! State changes that are not related to transactions.
 
 use super::{calc, BlockExecutionError};
-use alloc::boxed::Box;
 use alloy_consensus::BlockHeader;
 use alloy_eips::eip4895::Withdrawal;
 use alloy_hardforks::EthereumHardforks;
@@ -124,15 +123,11 @@ where
             BlockExecutionError::msg("could not load account for balance increment")
         })?;
 
-        Ok((
-            *address,
-            Account {
-                info: account.clone(),
-                original_info: Box::new(account.clone()),
-                status: AccountStatus::Touched,
-                ..Default::default()
-            },
-        ))
+        let mut acc = Account::default();
+        acc.info = account.clone();
+        acc.status = AccountStatus::Touched;
+        acc.set_current_info_as_original();
+        Ok((*address, acc))
     };
 
     balance_increments

--- a/crates/evm/src/overrides.rs
+++ b/crates/evm/src/overrides.rs
@@ -3,7 +3,7 @@
 //! This module provides helper functions for RPC implementations, including:
 //! - Block and state overrides
 
-use alloc::{boxed::Box, collections::BTreeMap};
+use alloc::collections::BTreeMap;
 use alloy_primitives::{keccak256, map::HashMap, Address, B256, U256};
 use alloy_rpc_types_eth::{
     state::{AccountOverride, StateOverride},
@@ -147,13 +147,10 @@ where
     }
 
     // Create a new account marked as touched
-    let mut acc = revm::state::Account {
-        info: info.clone(),
-        original_info: Box::new(info),
-        status: AccountStatus::Touched,
-        storage: Default::default(),
-        transaction_id: 0,
-    };
+    let mut acc = revm::state::Account::default();
+    acc.info = info;
+    acc.status = AccountStatus::Touched;
+    acc.set_current_info_as_original();
 
     let storage_diff = match (account_override.state, account_override.state_diff) {
         (Some(_), Some(_)) => return Err(StateOverrideError::BothStateAndStateDiff(account)),
@@ -163,13 +160,9 @@ where
         // used.
         (Some(state), None) => {
             // Destroy the account to ensure that its storage is cleared
-            db.commit(HashMap::from_iter([(
-                account,
-                Account {
-                    status: AccountStatus::SelfDestructed | AccountStatus::Touched,
-                    ..Default::default()
-                },
-            )]));
+            let mut destroyed = Account::default();
+            destroyed.status = AccountStatus::SelfDestructed | AccountStatus::Touched;
+            db.commit(HashMap::from_iter([(account, destroyed)]));
             // Mark the account as created to ensure that old storage is not read
             acc.mark_created();
             Some(state)

--- a/crates/evm/src/precompiles.rs
+++ b/crates/evm/src/precompiles.rs
@@ -3,7 +3,6 @@
 use crate::{Database, EvmInternals};
 use alloc::{
     borrow::Cow,
-    boxed::Box,
     string::{String, ToString},
     sync::Arc,
     vec::Vec,
@@ -566,8 +565,11 @@ where
         Ok(Some(precompile_output_to_interpreter_result(precompile_output, inputs.gas_limit)))
     }
 
-    fn warm_addresses(&self) -> Box<impl Iterator<Item = Address>> {
-        Box::new(self.addresses().copied())
+    fn warm_addresses(&self) -> &AddressSet {
+        match &self.precompiles {
+            PrecompilesKind::Builtin(precompiles) => precompiles.addresses_set(),
+            PrecompilesKind::Dynamic(dyn_precompiles) => &dyn_precompiles.addresses,
+        }
     }
 
     fn contains(&self, address: &Address) -> bool {


### PR DESCRIPTION
## Summary
- Bump pinned revm git rev to `3ed3bdfed9ad6e5ba37f4e1f015436ab89ca98be` ("refactor(eip8037): drop block_gas_limit from Cfg::cpsb")
- Bump workspace `revm` version constraint from 37.0.0 → 38.0.0 so the `[patch.crates-io]` entries actually apply (the new rev publishes revm at 38.0.0; without the bump cargo silently falls back to the registry release)

## Test plan
- [x] `cargo build --workspace`
- [x] `cargo check --workspace --all-targets`