### PR TITLE
docs: fix stale zero-withdrawal comment

### DIFF
--- a/crates/evm/src/block/state_changes.rs
+++ b/crates/evm/src/block/state_changes.rs
@@ -83,8 +83,6 @@ pub fn post_block_withdrawals_balance_increments(
 
 /// Applies all withdrawal balance increments if shanghai is active at the given timestamp to the
 /// given `balance_increments` map.
-///
-/// Zero-valued withdrawals are filtered out.
 #[inline]
 pub fn insert_post_block_withdrawals_balance_increments(
     spec: impl EthereumHardforks,


### PR DESCRIPTION
## Summary
- Remove the outdated note that `insert_post_block_withdrawals_balance_increments` filters out zero-valued withdrawals
- Keep the doc comment aligned with the helper’s actual behavior

## Testing
- Not run (not requested)