### PR TITLE
feat(evm): add indexed transaction execution

### DIFF
--- a/crates/evm/src/block/mod.rs
+++ b/crates/evm/src/block/mod.rs
@@ -262,6 +262,55 @@ pub trait BlockExecutor {
         self.execute_transaction_with_result_closure(tx, |_| ())
     }
 
+    /// Executes a single transaction at its zero-based index in the block and applies execution
+    /// result to internal state.
+    ///
+    /// This is equivalent to [`execute_transaction`](Self::execute_transaction), but first sets
+    /// the underlying database's BAL index for the transaction's position in the block. BAL uses
+    /// index `0` for pre-execution changes, transaction indexes are shifted by one (`tx_index + 1`)
+    /// and post-execution changes use the index after the last transaction. This means transaction
+    /// `0` is executed at BAL index `1`, transaction `1` at BAL index `2`, and so on.
+    ///
+    /// Callers that execute transactions individually should prefer this method when the
+    /// transaction index in the block is known, so BAL reads and writes are attributed to the
+    /// correct EIP-7928 index.
+    fn execute_transaction_with_index(
+        &mut self,
+        tx: impl ExecutableTx<Self>,
+        tx_index: usize,
+    ) -> Result<GasOutput, BlockExecutionError>
+    where
+        <Self::Evm as Evm>::DB: BalIndexedDatabase,
+    {
+        self.execute_transaction_with_index_and_result_closure(tx, tx_index, |_| ())
+    }
+
+    /// Executes a single transaction at its zero-based index in the block and invokes the given
+    /// closure with the internal [`Self::Result`](BlockExecutor::Result) produced by the EVM.
+    ///
+    /// This is the indexed counterpart to
+    /// [`execute_transaction_with_result_closure`](Self::execute_transaction_with_result_closure).
+    /// It first sets the underlying database's BAL index for the transaction's position in the
+    /// block, then executes and commits the transaction while exposing the raw execution result to
+    /// the closure.
+    ///
+    /// BAL uses index `0` for pre-execution changes, transaction indexes are shifted by one
+    /// (`tx_index + 1`) and post-execution changes use the index after the last transaction. This
+    /// means transaction `0` is executed at BAL index `1`, transaction `1` at BAL index `2`, and so
+    /// on.
+    fn execute_transaction_with_index_and_result_closure(
+        &mut self,
+        tx: impl ExecutableTx<Self>,
+        tx_index: usize,
+        f: impl FnOnce(&Self::Result),
+    ) -> Result<GasOutput, BlockExecutionError>
+    where
+        <Self::Evm as Evm>::DB: BalIndexedDatabase,
+    {
+        self.evm_mut().db_mut().set_bal_index(tx_index as u64 + 1);
+        self.execute_transaction_with_result_closure(tx, f)
+    }
+
     /// Executes a single transaction and applies execution result to internal state. Invokes the
     /// given closure with an internal [`Self::Result`](BlockExecutor::Result) produced by the EVM.
     ///

--- a/crates/evm/src/block/state.rs
+++ b/crates/evm/src/block/state.rs
@@ -1,9 +1,71 @@
 //! State database abstraction.
 
 use crate::Database;
-use revm::DatabaseCommit;
+use revm::{database::State, database_interface::bal::BalDatabase, DatabaseCommit};
+
+/// Database that tracks the current block-level access list (BAL) index from EIP-7928.
+///
+/// BAL values are indexed by their position in block execution. Index `0` is reserved for
+/// pre-transaction block execution changes, such as system contract calls. Regular transactions
+/// start at index `1`, so transaction `0` in the block uses BAL index `1`, transaction `1` uses BAL
+/// index `2`, and so on. Post-transaction block execution changes use the index after the last
+/// transaction.
+pub trait BalIndexedDatabase: Database {
+    /// Sets the current EIP-7928 BAL index for subsequent database reads and writes.
+    ///
+    /// Use index `0` for pre-transaction block execution, `tx_index + 1` for regular transactions
+    /// in the block, and the next index after the last transaction for post-transaction block
+    /// execution. In other words, regular block transactions start at BAL index `1`.
+    fn set_bal_index(&mut self, index: u64);
+
+    /// Advances the current BAL index.
+    fn bump_bal_index(&mut self);
+}
+
+impl<DB> BalIndexedDatabase for State<DB>
+where
+    Self: Database,
+{
+    fn set_bal_index(&mut self, index: u64) {
+        self.bal_state.bal_index = index;
+    }
+
+    fn bump_bal_index(&mut self) {
+        self.bal_state.bump_bal_index();
+    }
+}
+
+impl<DB> BalIndexedDatabase for BalDatabase<DB>
+where
+    Self: Database,
+{
+    fn set_bal_index(&mut self, index: u64) {
+        self.bal_state.bal_index = index;
+    }
+
+    fn bump_bal_index(&mut self) {
+        self.bal_state.bump_bal_index();
+    }
+}
 
 /// Alias trait for [`Database`] and [`DatabaseCommit`].
 pub trait StateDB: Database + DatabaseCommit {}
 
 impl<T> StateDB for T where T: Database + DatabaseCommit {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use revm::{database::CacheDB, database_interface::EmptyDB};
+
+    #[test]
+    fn state_sets_and_bumps_bal_index() {
+        let mut db = State::builder().with_database(CacheDB::new(EmptyDB::new())).build();
+
+        BalIndexedDatabase::set_bal_index(&mut db, 7);
+        assert_eq!(db.bal_state.bal_index, 7);
+
+        BalIndexedDatabase::bump_bal_index(&mut db);
+        assert_eq!(db.bal_state.bal_index, 8);
+    }
+}


### PR DESCRIPTION
Adds `BlockExecutor::execute_transaction_with_index` and `BlockExecutor::execute_transaction_with_index_and_result_closure` helpers that accept a zero-based block transaction index and map it to the BAL index used by revm state databases. Transaction index `0` maps to BAL index `1`, leaving BAL index `0` for pre-execution changes.

Introduces a `BalIndexedDatabase` database capability for EIP-7928 BAL-aware databases, with implementations for revm `State` and `BalDatabase`.

The existing `execute_block`, pre-execution, and post-execution paths are left unchanged. Callers opt into BAL indexing only by calling the indexed transaction helpers when they know the transaction position in the block.
