### PR TITLE
refactor: introduce `BalEvm`

### DIFF
--- a/crates/evm/Cargo.toml
+++ b/crates/evm/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 
 [dependencies]
 alloy-consensus = { workspace = true, features = ["k256"] }
+alloy-eip7928 = { version = "0.4", default-features = false }
 alloy-primitives.workspace = true
 alloy-sol-types.workspace = true
 alloy-eips.workspace = true
@@ -50,7 +51,8 @@ std = [
 	"thiserror/std",
 	"alloy-rpc-types-eth?/std",
 	"alloy-rpc-types-engine?/std",
-	"tracing/std"
+	"tracing/std",
+	"alloy-eip7928/std",
 ]
 gmp = [
     "revm/gmp",

--- a/crates/evm/src/block/mod.rs
+++ b/crates/evm/src/block/mod.rs
@@ -3,6 +3,7 @@
 use crate::{Evm, EvmFactory, FromRecoveredTx, FromTxWithEncoded, RecoveredTx, ToTxEnv};
 use alloc::{boxed::Box, vec::Vec};
 use alloy_consensus::transaction::Recovered;
+use alloy_eip7928::BlockAccessList;
 use alloy_eips::{eip2718::WithEncoded, eip7685::Requests};
 use revm::{
     context::result::ResultAndState, context_interface::either::Either, inspector::NoOpInspector,
@@ -39,6 +40,8 @@ pub struct BlockExecutionResult<T> {
     pub gas_used: u64,
     /// Blob gas used by the block.
     pub blob_gas_used: u64,
+    /// The block access list.
+    pub block_access_list: Option<BlockAccessList>,
 }
 
 impl<T> Default for BlockExecutionResult<T> {
@@ -48,6 +51,7 @@ impl<T> Default for BlockExecutionResult<T> {
             requests: Default::default(),
             gas_used: 0,
             blob_gas_used: 0,
+            block_access_list: None,
         }
     }
 }
@@ -264,55 +268,6 @@ pub trait BlockExecutor {
         self.execute_transaction_with_result_closure(tx, |_| ())
     }
 
-    /// Executes a single transaction at its zero-based index in the block and applies execution
-    /// result to internal state.
-    ///
-    /// This is equivalent to [`execute_transaction`](Self::execute_transaction), but first sets
-    /// the underlying database's BAL index for the transaction's position in the block. BAL uses
-    /// index `0` for pre-execution changes, transaction indexes are shifted by one (`tx_index + 1`)
-    /// and post-execution changes use the index after the last transaction. This means transaction
-    /// `0` is executed at BAL index `1`, transaction `1` at BAL index `2`, and so on.
-    ///
-    /// Callers that execute transactions individually should prefer this method when the
-    /// transaction index in the block is known, so BAL reads and writes are attributed to the
-    /// correct EIP-7928 index.
-    fn execute_transaction_with_index(
-        &mut self,
-        tx: impl ExecutableTx<Self>,
-        tx_index: usize,
-    ) -> Result<GasOutput, BlockExecutionError>
-    where
-        <Self::Evm as Evm>::DB: BalIndexedDatabase,
-    {
-        self.execute_transaction_with_index_and_result_closure(tx, tx_index, |_| ())
-    }
-
-    /// Executes a single transaction at its zero-based index in the block and invokes the given
-    /// closure with the internal [`Self::Result`](BlockExecutor::Result) produced by the EVM.
-    ///
-    /// This is the indexed counterpart to
-    /// [`execute_transaction_with_result_closure`](Self::execute_transaction_with_result_closure).
-    /// It first sets the underlying database's BAL index for the transaction's position in the
-    /// block, then executes and commits the transaction while exposing the raw execution result to
-    /// the closure.
-    ///
-    /// BAL uses index `0` for pre-execution changes, transaction indexes are shifted by one
-    /// (`tx_index + 1`) and post-execution changes use the index after the last transaction. This
-    /// means transaction `0` is executed at BAL index `1`, transaction `1` at BAL index `2`, and so
-    /// on.
-    fn execute_transaction_with_index_and_result_closure(
-        &mut self,
-        tx: impl ExecutableTx<Self>,
-        tx_index: usize,
-        f: impl FnOnce(&Self::Result),
-    ) -> Result<GasOutput, BlockExecutionError>
-    where
-        <Self::Evm as Evm>::DB: BalIndexedDatabase,
-    {
-        self.evm_mut().db_mut().set_bal_index(tx_index as u64 + 1);
-        self.execute_transaction_with_result_closure(tx, f)
-    }
-
     /// Executes a single transaction and applies execution result to internal state. Invokes the
     /// given closure with an internal [`Self::Result`](BlockExecutor::Result) produced by the EVM.
     ///
@@ -388,6 +343,20 @@ pub trait BlockExecutor {
         &mut self,
         tx: impl ExecutableTx<Self>,
     ) -> Result<Self::Result, BlockExecutionError>;
+
+    /// Executes a single transaction without committing state changes.
+    ///
+    /// Implementors must override this method to support out-of-order execution.
+    fn execute_transaction_with_index(
+        &mut self,
+        tx: impl ExecutableTx<Self>,
+        index: usize,
+    ) -> Result<Self::Result, BlockExecutionError> {
+        if self.receipts().len() != index {
+            return Err(BlockExecutionError::msg("out-of-order execution is not supported"));
+        }
+        self.execute_transaction_without_commit(tx)
+    }
 
     /// Commits a previously executed transaction's state changes.
     ///
@@ -567,7 +536,7 @@ pub trait BlockExecutorFactory: 'static {
     ///   block.
     /// - Should be lightweight (use references where possible)
     /// - Contains only block-level data, not transaction-specific data
-    type ExecutionCtx<'a>: Clone;
+    type ExecutionCtx<'a>: Send + Sync + Clone;
 
     /// Transaction type used by the executor, see [`BlockExecutor::Transaction`].
     ///

--- a/crates/evm/src/block/state.rs
+++ b/crates/evm/src/block/state.rs
@@ -1,74 +1,9 @@
 //! State database abstraction.
 
 use crate::Database;
-use revm::{
-    database::State, database_interface::bal::BalDatabase, state::bal::BlockAccessIndex,
-    DatabaseCommit,
-};
-
-/// Database that tracks the current block-level access list (BAL) index from EIP-7928.
-///
-/// BAL values are indexed by their position in block execution. Index `0` is reserved for
-/// pre-transaction block execution changes, such as system contract calls. Regular transactions
-/// start at index `1`, so transaction `0` in the block uses BAL index `1`, transaction `1` uses BAL
-/// index `2`, and so on. Post-transaction block execution changes use the index after the last
-/// transaction.
-pub trait BalIndexedDatabase: Database {
-    /// Sets the current EIP-7928 BAL index for subsequent database reads and writes.
-    ///
-    /// Use index `0` for pre-transaction block execution, `tx_index + 1` for regular transactions
-    /// in the block, and the next index after the last transaction for post-transaction block
-    /// execution. In other words, regular block transactions start at BAL index `1`.
-    fn set_bal_index(&mut self, index: u64);
-
-    /// Advances the current BAL index.
-    fn bump_bal_index(&mut self);
-}
-
-impl<DB> BalIndexedDatabase for State<DB>
-where
-    Self: Database,
-{
-    fn set_bal_index(&mut self, index: u64) {
-        self.bal_state.bal_index = BlockAccessIndex::new(index);
-    }
-
-    fn bump_bal_index(&mut self) {
-        self.bal_state.bump_bal_index();
-    }
-}
-
-impl<DB> BalIndexedDatabase for BalDatabase<DB>
-where
-    Self: Database,
-{
-    fn set_bal_index(&mut self, index: u64) {
-        self.bal_state.bal_index = BlockAccessIndex::new(index);
-    }
-
-    fn bump_bal_index(&mut self) {
-        self.bal_state.bump_bal_index();
-    }
-}
+use revm::DatabaseCommit;
 
 /// Alias trait for [`Database`] and [`DatabaseCommit`].
 pub trait StateDB: Database + DatabaseCommit {}
 
 impl<T> StateDB for T where T: Database + DatabaseCommit {}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use revm::{database::CacheDB, database_interface::EmptyDB};
-
-    #[test]
-    fn state_sets_and_bumps_bal_index() {
-        let mut db = State::builder().with_database(CacheDB::new(EmptyDB::new())).build();
-
-        BalIndexedDatabase::set_bal_index(&mut db, 7);
-        assert_eq!(db.bal_state.bal_index, BlockAccessIndex::new(7));
-
-        BalIndexedDatabase::bump_bal_index(&mut db);
-        assert_eq!(db.bal_state.bal_index, BlockAccessIndex::new(8));
-    }
-}

--- a/crates/evm/src/eth/block.rs
+++ b/crates/evm/src/eth/block.rs
@@ -15,15 +15,21 @@ use crate::{
         BlockValidationError, ExecutableTx, GasOutput, OnStateHook, StateChangePostBlockSource,
         StateChangeSource, StateDB, SystemCaller, TxResult,
     },
-    Evm, EvmFactory, FromRecoveredTx, FromTxWithEncoded, RecoveredTx,
+    eth::EthEvmContext,
+    evm::BalEvm,
+    precompiles::PrecompilesMap,
+    EthEvm, Evm, FromRecoveredTx, FromTxWithEncoded, RecoveredTx,
 };
-use alloc::{borrow::Cow, boxed::Box, vec::Vec};
+use alloc::{borrow::Cow, boxed::Box, sync::Arc, vec::Vec};
 use alloy_consensus::{Header, Transaction, TransactionEnvelope, TxReceipt};
+use alloy_eip7928::BlockAccessIndex;
 use alloy_eips::{eip4895::Withdrawal, eip7685::Requests, Encodable2718};
 use alloy_hardforks::EthereumHardfork;
 use alloy_primitives::{Bytes, Log, B256};
 use revm::{
-    context::Block, context_interface::result::ResultAndState, database::DatabaseCommitExt,
+    context::{result::HaltReason, Block, TxEnv},
+    context_interface::result::ResultAndState,
+    database::DatabaseCommitExt,
     DatabaseCommit, Inspector,
 };
 
@@ -44,6 +50,9 @@ pub struct EthBlockExecutionCtx<'a> {
     pub tx_count_hint: Option<usize>,
     /// Slot number (EIP-7843, Amsterdam).
     pub slot_number: Option<u64>,
+    /// Block access list. Fully optional and might be omitted during block building or for
+    /// pre-Amsterdam blocks.
+    pub block_access_list: Option<Arc<revm::state::bal::Bal>>,
 }
 
 /// Block executor for Ethereum.
@@ -106,13 +115,19 @@ where
 impl<'a, Evm, Spec, R> EthBlockExecutor<'a, Evm, Spec, R>
 where
     R: ReceiptBuilder,
+    Evm: BalEvm,
 {
     /// Creates a new [`EthBlockExecutor`]
-    pub fn new(evm: Evm, ctx: EthBlockExecutionCtx<'a>, spec: Spec, receipt_builder: R) -> Self
+    pub fn new(mut evm: Evm, ctx: EthBlockExecutionCtx<'a>, spec: Spec, receipt_builder: R) -> Self
     where
         Spec: Clone,
     {
         let tx_count_hint = ctx.tx_count_hint.unwrap_or_default();
+
+        if let Some(bal) = &ctx.block_access_list {
+            evm.set_bal(bal.clone());
+        }
+
         Self {
             evm,
             ctx,
@@ -139,7 +154,8 @@ where
 
 impl<E, Spec, R> BlockExecutor for EthBlockExecutor<'_, E, Spec, R>
 where
-    E: Evm<DB: StateDB, Tx: FromRecoveredTx<R::Transaction> + FromTxWithEncoded<R::Transaction>>,
+    E: Evm<DB: StateDB, Tx: FromRecoveredTx<R::Transaction> + FromTxWithEncoded<R::Transaction>>
+        + BalEvm,
     Spec: EthExecutorSpec,
     R: ReceiptBuilder<Transaction: Transaction + Encodable2718, Receipt: TxReceipt<Log = Log>>,
     <R::Transaction as TransactionEnvelope>::TxType: Send + 'static,
@@ -150,9 +166,20 @@ where
     type Result = EthTxResult<E::HaltReason, <R::Transaction as TransactionEnvelope>::TxType>;
 
     fn apply_pre_execution_changes(&mut self) -> Result<(), BlockExecutionError> {
+        // If BAL is provided or this is a post-Amsterdam block, trigger BAL building
+        if self.ctx.block_access_list.is_some()
+            || self
+                .spec
+                .is_amsterdam_active_at_timestamp(self.evm.block().timestamp().saturating_to())
+        {
+            self.evm.enable_bal_building();
+        }
+
         self.system_caller.apply_blockhashes_contract_call(self.ctx.parent_hash, &mut self.evm)?;
         self.system_caller
             .apply_beacon_root_contract_call(self.ctx.parent_beacon_block_root, &mut self.evm)?;
+
+        self.evm.bump_bal_index();
 
         Ok(())
     }
@@ -205,6 +232,20 @@ where
         })
     }
 
+    fn execute_transaction_with_index(
+        &mut self,
+        tx: impl ExecutableTx<Self>,
+        index: usize,
+    ) -> Result<Self::Result, BlockExecutionError> {
+        if self.ctx.block_access_list.is_none() {
+            return Err(BlockExecutionError::msg("block access list is not available"));
+        }
+
+        self.evm.set_index(BlockAccessIndex::new((index + 1) as u64));
+
+        self.execute_transaction_without_commit(tx)
+    }
+
     fn commit_transaction(&mut self, output: Self::Result) -> GasOutput {
         let EthTxResult { result: ResultAndState { result, state }, blob_gas_used, tx_type } =
             output;
@@ -236,6 +277,7 @@ where
 
         // Commit the state changes.
         self.evm.db_mut().commit(state);
+        self.evm.bump_bal_index();
 
         GasOutput::with_state_gas(tx_gas_used, state_gas_used)
     }
@@ -301,6 +343,14 @@ where
 
         self.evm.db_mut().commit(balance_increment_state);
 
+        let bal = self.evm.take_built_bal();
+
+        if let Some(provided_bal) = &self.ctx.block_access_list {
+            if bal.as_ref() != Some(provided_bal.as_ref()) {
+                return Err(BlockValidationError::msg("invalid BAL provided").into());
+            }
+        }
+
         // Pre-Amsterdam: use tx_gas_used (with refunds) for the block gas total.
         // Amsterdam+: use max(regular, state) gas without refunds (EIP-8037).
         let gas_used = if self.evm.cfg_env().enable_amsterdam_eip8037 {
@@ -316,6 +366,7 @@ where
                 requests,
                 gas_used,
                 blob_gas_used: self.blob_gas_used,
+                block_access_list: bal.map(|bal| bal.into_alloy_bal()),
             },
         ))
     }
@@ -375,24 +426,22 @@ impl<R, Spec, EvmFactory> EthBlockExecutorFactory<R, Spec, EvmFactory> {
     }
 }
 
-impl<R, Spec, EvmF> BlockExecutorFactory for EthBlockExecutorFactory<R, Spec, EvmF>
+impl<R, Spec> BlockExecutorFactory for EthBlockExecutorFactory<R, Spec>
 where
     R: ReceiptBuilder<Transaction: Transaction + Encodable2718, Receipt: TxReceipt<Log = Log>>,
     Spec: EthExecutorSpec,
-    EvmF: EvmFactory<Tx: FromRecoveredTx<R::Transaction> + FromTxWithEncoded<R::Transaction>>,
+    TxEnv: FromRecoveredTx<R::Transaction> + FromTxWithEncoded<R::Transaction>,
     <R::Transaction as TransactionEnvelope>::TxType: Send + 'static,
     Self: 'static,
 {
-    type EvmFactory = EvmF;
+    type EvmFactory = EthEvmFactory;
     type ExecutionCtx<'a> = EthBlockExecutionCtx<'a>;
     type Transaction = R::Transaction;
     type Receipt = R::Receipt;
-    type TxExecutionResult = EthTxResult<
-        <EvmF as EvmFactory>::HaltReason,
-        <R::Transaction as TransactionEnvelope>::TxType,
-    >;
-    type Executor<'a, DB: StateDB, I: Inspector<EvmF::Context<DB>>> =
-        EthBlockExecutor<'a, EvmF::Evm<DB, I>, &'a Spec, &'a R>;
+    type TxExecutionResult =
+        EthTxResult<HaltReason, <R::Transaction as TransactionEnvelope>::TxType>;
+    type Executor<'a, DB: StateDB, I: Inspector<EthEvmContext<DB>>> =
+        EthBlockExecutor<'a, EthEvm<DB, I, PrecompilesMap>, &'a Spec, &'a R>;
 
     fn evm_factory(&self) -> &Self::EvmFactory {
         &self.evm_factory
@@ -400,12 +449,12 @@ where
 
     fn create_executor<'a, DB, I>(
         &'a self,
-        evm: EvmF::Evm<DB, I>,
+        evm: EthEvm<DB, I, PrecompilesMap>,
         ctx: Self::ExecutionCtx<'a>,
     ) -> Self::Executor<'a, DB, I>
     where
         DB: StateDB,
-        I: Inspector<EvmF::Context<DB>>,
+        I: Inspector<EthEvmContext<DB>>,
     {
         EthBlockExecutor::new(evm, ctx, &self.spec, &self.receipt_builder)
     }

--- a/crates/evm/src/eth/block.rs
+++ b/crates/evm/src/eth/block.rs
@@ -15,10 +15,8 @@ use crate::{
         BlockValidationError, ExecutableTx, GasOutput, OnStateHook, StateChangePostBlockSource,
         StateChangeSource, StateDB, SystemCaller, TxResult,
     },
-    eth::EthEvmContext,
     evm::BalEvm,
-    precompiles::PrecompilesMap,
-    EthEvm, Evm, FromRecoveredTx, FromTxWithEncoded, RecoveredTx,
+    Evm, EvmFactory, FromRecoveredTx, FromTxWithEncoded, RecoveredTx,
 };
 use alloc::{borrow::Cow, boxed::Box, sync::Arc, vec::Vec};
 use alloy_consensus::{Header, Transaction, TransactionEnvelope, TxReceipt};
@@ -27,9 +25,7 @@ use alloy_eips::{eip4895::Withdrawal, eip7685::Requests, Encodable2718};
 use alloy_hardforks::EthereumHardfork;
 use alloy_primitives::{Bytes, Log, B256};
 use revm::{
-    context::{result::HaltReason, Block, TxEnv},
-    context_interface::result::ResultAndState,
-    database::DatabaseCommitExt,
+    context::Block, context_interface::result::ResultAndState, database::DatabaseCommitExt,
     DatabaseCommit, Inspector,
 };
 
@@ -112,20 +108,22 @@ where
     }
 }
 
-impl<'a, Evm, Spec, R> EthBlockExecutor<'a, Evm, Spec, R>
+impl<'a, E, Spec, R> EthBlockExecutor<'a, E, Spec, R>
 where
     R: ReceiptBuilder,
-    Evm: BalEvm,
+    E: Evm,
 {
     /// Creates a new [`EthBlockExecutor`]
-    pub fn new(mut evm: Evm, ctx: EthBlockExecutionCtx<'a>, spec: Spec, receipt_builder: R) -> Self
+    pub fn new(mut evm: E, ctx: EthBlockExecutionCtx<'a>, spec: Spec, receipt_builder: R) -> Self
     where
         Spec: Clone,
     {
         let tx_count_hint = ctx.tx_count_hint.unwrap_or_default();
 
         if let Some(bal) = &ctx.block_access_list {
-            evm.set_bal(bal.clone());
+            if let Some(bal_evm) = evm.as_bal_evm_mut() {
+                bal_evm.set_bal(bal.clone());
+            }
         }
 
         Self {
@@ -150,12 +148,26 @@ where
         }
         self.block_state_gas_used
     }
+
+    /// Returns a mutable reference to [`BalEvm`] if underlying EVM supports it, otherwise returns
+    /// an error.
+    fn bal_evm_mut(&mut self) -> Result<&mut dyn BalEvm, BlockExecutionError> {
+        self.evm
+            .as_bal_evm_mut()
+            .ok_or_else(|| BlockExecutionError::msg("EVM does not support block access lists"))
+    }
+
+    /// Bumps the BAL index if underlying EVM supports it.
+    fn bump_bal_index(&mut self) {
+        if let Some(bal_evm) = self.evm.as_bal_evm_mut() {
+            bal_evm.bump_bal_index();
+        }
+    }
 }
 
 impl<E, Spec, R> BlockExecutor for EthBlockExecutor<'_, E, Spec, R>
 where
-    E: Evm<DB: StateDB, Tx: FromRecoveredTx<R::Transaction> + FromTxWithEncoded<R::Transaction>>
-        + BalEvm,
+    E: Evm<DB: StateDB, Tx: FromRecoveredTx<R::Transaction> + FromTxWithEncoded<R::Transaction>>,
     Spec: EthExecutorSpec,
     R: ReceiptBuilder<Transaction: Transaction + Encodable2718, Receipt: TxReceipt<Log = Log>>,
     <R::Transaction as TransactionEnvelope>::TxType: Send + 'static,
@@ -172,14 +184,14 @@ where
                 .spec
                 .is_amsterdam_active_at_timestamp(self.evm.block().timestamp().saturating_to())
         {
-            self.evm.enable_bal_building();
+            self.bal_evm_mut()?.enable_bal_building();
         }
 
         self.system_caller.apply_blockhashes_contract_call(self.ctx.parent_hash, &mut self.evm)?;
         self.system_caller
             .apply_beacon_root_contract_call(self.ctx.parent_beacon_block_root, &mut self.evm)?;
 
-        self.evm.bump_bal_index();
+        self.bump_bal_index();
 
         Ok(())
     }
@@ -241,7 +253,7 @@ where
             return Err(BlockExecutionError::msg("block access list is not available"));
         }
 
-        self.evm.set_index(BlockAccessIndex::new((index + 1) as u64));
+        self.bal_evm_mut()?.set_index(BlockAccessIndex::new((index + 1) as u64));
 
         self.execute_transaction_without_commit(tx)
     }
@@ -277,7 +289,7 @@ where
 
         // Commit the state changes.
         self.evm.db_mut().commit(state);
-        self.evm.bump_bal_index();
+        self.bump_bal_index();
 
         GasOutput::with_state_gas(tx_gas_used, state_gas_used)
     }
@@ -343,7 +355,7 @@ where
 
         self.evm.db_mut().commit(balance_increment_state);
 
-        let bal = self.evm.take_built_bal();
+        let bal = self.evm.as_bal_evm_mut().and_then(|bal_evm| bal_evm.take_built_bal());
 
         if let Some(provided_bal) = &self.ctx.block_access_list {
             if bal.as_ref() != Some(provided_bal.as_ref()) {
@@ -426,22 +438,24 @@ impl<R, Spec, EvmFactory> EthBlockExecutorFactory<R, Spec, EvmFactory> {
     }
 }
 
-impl<R, Spec> BlockExecutorFactory for EthBlockExecutorFactory<R, Spec>
+impl<R, Spec, EvmF> BlockExecutorFactory for EthBlockExecutorFactory<R, Spec, EvmF>
 where
     R: ReceiptBuilder<Transaction: Transaction + Encodable2718, Receipt: TxReceipt<Log = Log>>,
     Spec: EthExecutorSpec,
-    TxEnv: FromRecoveredTx<R::Transaction> + FromTxWithEncoded<R::Transaction>,
+    EvmF: EvmFactory<Tx: FromRecoveredTx<R::Transaction> + FromTxWithEncoded<R::Transaction>>,
     <R::Transaction as TransactionEnvelope>::TxType: Send + 'static,
     Self: 'static,
 {
-    type EvmFactory = EthEvmFactory;
+    type EvmFactory = EvmF;
     type ExecutionCtx<'a> = EthBlockExecutionCtx<'a>;
     type Transaction = R::Transaction;
     type Receipt = R::Receipt;
-    type TxExecutionResult =
-        EthTxResult<HaltReason, <R::Transaction as TransactionEnvelope>::TxType>;
-    type Executor<'a, DB: StateDB, I: Inspector<EthEvmContext<DB>>> =
-        EthBlockExecutor<'a, EthEvm<DB, I, PrecompilesMap>, &'a Spec, &'a R>;
+    type TxExecutionResult = EthTxResult<
+        <EvmF as EvmFactory>::HaltReason,
+        <R::Transaction as TransactionEnvelope>::TxType,
+    >;
+    type Executor<'a, DB: StateDB, I: Inspector<EvmF::Context<DB>>> =
+        EthBlockExecutor<'a, EvmF::Evm<DB, I>, &'a Spec, &'a R>;
 
     fn evm_factory(&self) -> &Self::EvmFactory {
         &self.evm_factory
@@ -449,12 +463,12 @@ where
 
     fn create_executor<'a, DB, I>(
         &'a self,
-        evm: EthEvm<DB, I, PrecompilesMap>,
+        evm: EvmF::Evm<DB, I>,
         ctx: Self::ExecutionCtx<'a>,
     ) -> Self::Executor<'a, DB, I>
     where
         DB: StateDB,
-        I: Inspector<EthEvmContext<DB>>,
+        I: Inspector<EvmF::Context<DB>>,
     {
         EthBlockExecutor::new(evm, ctx, &self.spec, &self.receipt_builder)
     }

--- a/crates/evm/src/eth/block.rs
+++ b/crates/evm/src/eth/block.rs
@@ -404,7 +404,7 @@ pub struct EthBlockExecutorFactory<
 }
 
 impl<R, Spec, EvmFactory> EthBlockExecutorFactory<R, Spec, EvmFactory> {
-    /// Creates a new [`EthBlockExecutorFactory`] with the given spec, [`EvmFactory`], and
+    /// Creates a new [`EthBlockExecutorFactory`] with the given spec, EVM factory, and
     /// [`ReceiptBuilder`].
     pub const fn new(receipt_builder: R, spec: Spec, evm_factory: EvmFactory) -> Self {
         Self { receipt_builder, spec, evm_factory }

--- a/crates/evm/src/eth/mod.rs
+++ b/crates/evm/src/eth/mod.rs
@@ -2,7 +2,13 @@
 
 pub use env::NextEvmEnvAttributes;
 
-use crate::{env::EvmEnv, evm::EvmFactory, precompiles::PrecompilesMap, Database, Evm};
+use crate::{
+    env::EvmEnv,
+    evm::{BalEvm, EvmFactory},
+    precompiles::PrecompilesMap,
+    Database, Evm,
+};
+use alloc::sync::Arc;
 use alloy_primitives::{Address, Bytes};
 use core::{
     fmt::Debug,
@@ -11,11 +17,13 @@ use core::{
 use revm::{
     context::{BlockEnv, CfgEnv, DBErrorMarker, Evm as RevmEvm, TxEnv},
     context_interface::result::{EVMError, HaltReason, ResultAndState},
+    database::bal::{BalDatabase, EvmDatabaseError},
     handler::{instructions::EthInstructions, EthFrame, EthPrecompiles, PrecompileProvider},
     inspector::NoOpInspector,
     interpreter::{interpreter::EthInterpreter, InterpreterResult},
     precompile::{PrecompileSpecId, Precompiles},
     primitives::hardfork::SpecId,
+    state::bal::{Bal, BlockAccessIndex},
     Context, ExecuteEvm, InspectEvm, Inspector, MainBuilder, MainContext, SystemCallEvm,
 };
 
@@ -31,7 +39,7 @@ mod env;
 pub(crate) mod spec_id;
 
 /// The Ethereum EVM context type.
-pub type EthEvmContext<DB> = Context<BlockEnv, TxEnv, CfgEnv, DB>;
+pub type EthEvmContext<DB> = Context<BlockEnv, TxEnv, CfgEnv, BalDatabase<DB>>;
 
 /// Helper builder to construct `EthEvm` instances in a unified way.
 #[derive(Debug)]
@@ -109,7 +117,7 @@ impl<DB: Database, I> EthEvmBuilder<DB, I> {
         let inner = Context::mainnet()
             .with_block(self.block_env)
             .with_cfg(self.cfg_env)
-            .with_db(self.db)
+            .with_db(BalDatabase::new(self.db))
             .build_mainnet_with_inspector(self.inspector)
             .with_precompiles(precompiles);
 
@@ -200,7 +208,7 @@ where
 {
     type DB = DB;
     type Tx = TxEnv;
-    type Error = EVMError<DB::Error>;
+    type Error = EVMError<<BalDatabase<DB> as revm::Database>::Error>;
     type HaltReason = HaltReason;
     type Spec = SpecId;
     type BlockEnv = BlockEnv;
@@ -242,7 +250,7 @@ where
     fn finish(self) -> (Self::DB, EvmEnv<Self::Spec>) {
         let Context { block: block_env, cfg: cfg_env, journaled_state, .. } = self.inner.ctx;
 
-        (journaled_state.database, EvmEnv { block_env, cfg_env })
+        (journaled_state.database.db, EvmEnv { block_env, cfg_env })
     }
 
     fn set_inspector_enabled(&mut self, enabled: bool) {
@@ -262,6 +270,28 @@ where
     }
 }
 
+impl<DB: Database, I, PRECOMPILE> BalEvm for EthEvm<DB, I, PRECOMPILE> {
+    fn set_bal(&mut self, bal: Arc<Bal>) {
+        self.inner.ctx.journaled_state.database.bal_state.bal = Some(bal);
+    }
+
+    fn enable_bal_building(&mut self) {
+        self.inner.ctx.journaled_state.database.bal_state.bal_builder = Some(Bal::new());
+    }
+
+    fn set_index(&mut self, index: BlockAccessIndex) {
+        self.inner.ctx.journaled_state.database.bal_state.bal_index = index;
+    }
+
+    fn bump_bal_index(&mut self) {
+        self.inner.ctx.journaled_state.database.bump_bal_index();
+    }
+
+    fn take_built_bal(&mut self) -> Option<Bal> {
+        self.inner.ctx.journaled_state.database.bal_state.take_built_bal()
+    }
+}
+
 /// Factory producing [`EthEvm`].
 #[derive(Debug, Default, Clone, Copy)]
 #[non_exhaustive]
@@ -269,9 +299,9 @@ pub struct EthEvmFactory;
 
 impl EvmFactory for EthEvmFactory {
     type Evm<DB: Database, I: Inspector<EthEvmContext<DB>>> = EthEvm<DB, I, Self::Precompiles>;
-    type Context<DB: Database> = Context<BlockEnv, TxEnv, CfgEnv, DB>;
+    type Context<DB: Database> = EthEvmContext<DB>;
     type Tx = TxEnv;
-    type Error<DBError: DBErrorMarker> = EVMError<DBError>;
+    type Error<DBError: DBErrorMarker> = EVMError<EvmDatabaseError<DBError>>;
     type HaltReason = HaltReason;
     type Spec = SpecId;
     type BlockEnv = BlockEnv;

--- a/crates/evm/src/eth/mod.rs
+++ b/crates/evm/src/eth/mod.rs
@@ -268,6 +268,10 @@ where
             &mut self.inner.precompiles,
         )
     }
+
+    fn as_bal_evm_mut(&mut self) -> Option<&mut dyn BalEvm> {
+        Some(self)
+    }
 }
 
 impl<DB: Database, I, PRECOMPILE> BalEvm for EthEvm<DB, I, PRECOMPILE> {

--- a/crates/evm/src/evm.rs
+++ b/crates/evm/src/evm.rs
@@ -1,6 +1,7 @@
 //! Abstraction over EVM.
 
 use crate::{env::BlockEnvironment, tracing::TxTracer, EvmEnv, EvmError, IntoTxEnv};
+use alloc::sync::Arc;
 use alloy_consensus::transaction::TxHashRef;
 use alloy_primitives::{Address, Bytes, B256};
 use core::{error::Error, fmt::Debug, hash::Hash};
@@ -11,6 +12,7 @@ use revm::{
         ContextTr,
     },
     inspector::{JournalExt, NoOpInspector},
+    state::bal::{Bal, BlockAccessIndex},
     DatabaseCommit, Inspector,
 };
 
@@ -255,6 +257,27 @@ pub trait EvmExt: Evm {
 /// Automatic implementation of [`EvmExt`] for all types that implement [`Evm`].
 impl<T: Evm> EvmExt for T {}
 
+/// An EVM implementation that supports BAL caching.
+pub trait BalEvm {
+    /// Sets the BAL to use for the block execution.
+    fn set_bal(&mut self, bal: Arc<Bal>);
+
+    /// Enables BAL building for the current block execution.
+    fn enable_bal_building(&mut self);
+
+    /// Sets an index of the next transaction to be executed.
+    ///
+    /// Caller must make sure to call [`Self::set_bal`] before for this to actually apply the
+    /// caching.
+    fn set_index(&mut self, index: BlockAccessIndex);
+
+    /// Bumps the BAL index. No-op if BAL building is not enabled.
+    fn bump_bal_index(&mut self);
+
+    /// Takes the built BAL. Will return [`None`] if [`Self::enable_bal_building`] was not called.
+    fn take_built_bal(&mut self) -> Option<Bal>;
+}
+
 /// A type responsible for creating instances of an ethereum virtual machine given a certain input.
 pub trait EvmFactory {
     /// The EVM type that this factory creates.
@@ -270,7 +293,7 @@ pub trait EvmFactory {
     >;
 
     /// The EVM context for inspectors
-    type Context<DB: Database>: ContextTr<Db = DB, Journal: JournalExt>;
+    type Context<DB: Database>: ContextTr<Journal: JournalExt>;
     /// Transaction environment.
     type Tx: IntoTxEnv<Self::Tx>;
     /// EVM error. See [`Evm::Error`].

--- a/crates/evm/src/evm.rs
+++ b/crates/evm/src/evm.rs
@@ -192,6 +192,11 @@ pub trait Evm {
         self.components_mut().1
     }
 
+    /// Returns this EVM as a mutable BAL-capable EVM, if supported.
+    fn as_bal_evm_mut(&mut self) -> Option<&mut dyn BalEvm> {
+        None
+    }
+
     /// Provides immutable references to the database, inspector and precompiles.
     fn components(&self) -> (&Self::DB, &Self::Inspector, &Self::Precompiles);
 

--- a/crates/evm/src/precompiles.rs
+++ b/crates/evm/src/precompiles.rs
@@ -467,12 +467,10 @@ impl PrecompilesMap {
     }
 
     /// Returns an iterator over references to precompile addresses.
-    pub fn addresses(&self) -> impl Iterator<Item = &Address> {
+    pub fn addresses(&self) -> &AddressSet {
         match &self.precompiles {
-            PrecompilesKind::Builtin(precompiles) => Either::Left(precompiles.addresses()),
-            PrecompilesKind::Dynamic(dyn_precompiles) => {
-                Either::Right(dyn_precompiles.addresses.iter())
-            }
+            PrecompilesKind::Builtin(precompiles) => precompiles.addresses_set(),
+            PrecompilesKind::Dynamic(dyn_precompiles) => &dyn_precompiles.addresses,
         }
     }
 
@@ -961,7 +959,7 @@ mod tests {
     use alloy_primitives::{address, Bytes};
     use revm::{
         context::Block,
-        database::EmptyDB,
+        database::{bal::BalDatabase, EmptyDB},
         precompile::{PrecompileId, PrecompileOutput},
         primitives::hardfork::SpecId,
     };
@@ -971,7 +969,7 @@ mod tests {
         let eth_precompiles = EthPrecompiles::new(SpecId::default());
         let mut spec_precompiles = PrecompilesMap::from(eth_precompiles);
 
-        let mut ctx = EthEvmContext::new(EmptyDB::default(), Default::default());
+        let mut ctx = EthEvmContext::new(BalDatabase::new(EmptyDB::default()), Default::default());
 
         // create a test input for the precompile (identity precompile)
         let identity_address = address!("0x0000000000000000000000000000000000000004");
@@ -1050,7 +1048,7 @@ mod tests {
         let expected_output = Bytes::from_static(b"processed: test data");
         let gas_limit = 1000;
 
-        let mut ctx = EthEvmContext::new(EmptyDB::default(), Default::default());
+        let mut ctx = EthEvmContext::new(BalDatabase::new(EmptyDB::default()), Default::default());
 
         // define a closure that implements the precompile functionality
         let closure_precompile = |input: PrecompileInput<'_>| -> PrecompileResult {
@@ -1119,7 +1117,7 @@ mod tests {
         let eth_precompiles = EthPrecompiles::new(SpecId::default());
         let mut spec_precompiles = PrecompilesMap::from(eth_precompiles);
 
-        let mut ctx = EthEvmContext::new(EmptyDB::default(), Default::default());
+        let mut ctx = EthEvmContext::new(BalDatabase::new(EmptyDB::default()), Default::default());
 
         // Define a custom address pattern for dynamic precompiles
         let dynamic_prefix = [0xDE, 0xAD];
@@ -1174,7 +1172,7 @@ mod tests {
         let eth_precompiles = EthPrecompiles::new(SpecId::default());
         let spec_precompiles = PrecompilesMap::from(eth_precompiles);
 
-        let mut ctx = EthEvmContext::new(EmptyDB::default(), Default::default());
+        let mut ctx = EthEvmContext::new(BalDatabase::new(EmptyDB::default()), Default::default());
 
         let identity_address = address!("0x0000000000000000000000000000000000000004");
         let test_input = Bytes::from_static(b"test data");
@@ -1239,7 +1237,7 @@ mod tests {
         let eth_precompiles = EthPrecompiles::new(SpecId::default());
         let mut spec_precompiles = PrecompilesMap::from(eth_precompiles);
 
-        let mut ctx = EthEvmContext::new(EmptyDB::default(), Default::default());
+        let mut ctx = EthEvmContext::new(BalDatabase::new(EmptyDB::default()), Default::default());
 
         // Identity precompile at address 0x04
         let identity_address = address!("0x0000000000000000000000000000000000000004");


### PR DESCRIPTION
introduces `BalEvm` which allows `EthBlockExecutor` to drive BAL building/verification internally, and adds BAL to `BlockExecutionResult`