### PR TITLE
feat: Amsterdam bal-devnet-7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,15 +63,15 @@ serde_json = "1"
 test-case = "3"
 
 [patch.crates-io]
-revm = { git = "https://github.com/bluealloy/revm", rev = "191c163a23569a94097c4f9a7291158183fce256" }
-revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "191c163a23569a94097c4f9a7291158183fce256" }
-revm-context = { git = "https://github.com/bluealloy/revm", rev = "191c163a23569a94097c4f9a7291158183fce256" }
-revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "191c163a23569a94097c4f9a7291158183fce256" }
-revm-database = { git = "https://github.com/bluealloy/revm", rev = "191c163a23569a94097c4f9a7291158183fce256" }
-revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "191c163a23569a94097c4f9a7291158183fce256" }
-revm-handler = { git = "https://github.com/bluealloy/revm", rev = "191c163a23569a94097c4f9a7291158183fce256" }
-revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "191c163a23569a94097c4f9a7291158183fce256" }
-revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "191c163a23569a94097c4f9a7291158183fce256" }
-revm-precompile = { git = "https://github.com/bluealloy/revm", rev = "191c163a23569a94097c4f9a7291158183fce256" }
-revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "191c163a23569a94097c4f9a7291158183fce256" }
-revm-state = { git = "https://github.com/bluealloy/revm", rev = "191c163a23569a94097c4f9a7291158183fce256" }
+revm = { git = "https://github.com/bluealloy/revm", rev = "9ccf9e5800e7308f0a591c0493ae8e0de35317f8" }
+revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "9ccf9e5800e7308f0a591c0493ae8e0de35317f8" }
+revm-context = { git = "https://github.com/bluealloy/revm", rev = "9ccf9e5800e7308f0a591c0493ae8e0de35317f8" }
+revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "9ccf9e5800e7308f0a591c0493ae8e0de35317f8" }
+revm-database = { git = "https://github.com/bluealloy/revm", rev = "9ccf9e5800e7308f0a591c0493ae8e0de35317f8" }
+revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "9ccf9e5800e7308f0a591c0493ae8e0de35317f8" }
+revm-handler = { git = "https://github.com/bluealloy/revm", rev = "9ccf9e5800e7308f0a591c0493ae8e0de35317f8" }
+revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "9ccf9e5800e7308f0a591c0493ae8e0de35317f8" }
+revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "9ccf9e5800e7308f0a591c0493ae8e0de35317f8" }
+revm-precompile = { git = "https://github.com/bluealloy/revm", rev = "9ccf9e5800e7308f0a591c0493ae8e0de35317f8" }
+revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "9ccf9e5800e7308f0a591c0493ae8e0de35317f8" }
+revm-state = { git = "https://github.com/bluealloy/revm", rev = "9ccf9e5800e7308f0a591c0493ae8e0de35317f8" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,3 +61,17 @@ serde = { version = "1", default-features = false, features = ["derive"] }
 thiserror = { version = "2.0.0", default-features = false }
 serde_json = "1"
 test-case = "3"
+
+[patch.crates-io]
+revm = { git = "https://github.com/bluealloy/revm", rev = "191c163a23569a94097c4f9a7291158183fce256" }
+revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "191c163a23569a94097c4f9a7291158183fce256" }
+revm-context = { git = "https://github.com/bluealloy/revm", rev = "191c163a23569a94097c4f9a7291158183fce256" }
+revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "191c163a23569a94097c4f9a7291158183fce256" }
+revm-database = { git = "https://github.com/bluealloy/revm", rev = "191c163a23569a94097c4f9a7291158183fce256" }
+revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "191c163a23569a94097c4f9a7291158183fce256" }
+revm-handler = { git = "https://github.com/bluealloy/revm", rev = "191c163a23569a94097c4f9a7291158183fce256" }
+revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "191c163a23569a94097c4f9a7291158183fce256" }
+revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "191c163a23569a94097c4f9a7291158183fce256" }
+revm-precompile = { git = "https://github.com/bluealloy/revm", rev = "191c163a23569a94097c4f9a7291158183fce256" }
+revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "191c163a23569a94097c4f9a7291158183fce256" }
+revm-state = { git = "https://github.com/bluealloy/revm", rev = "191c163a23569a94097c4f9a7291158183fce256" }

--- a/crates/evm/src/block/state.rs
+++ b/crates/evm/src/block/state.rs
@@ -1,7 +1,10 @@
 //! State database abstraction.
 
 use crate::Database;
-use revm::{database::State, database_interface::bal::BalDatabase, DatabaseCommit};
+use revm::{
+    database::State, database_interface::bal::BalDatabase, state::bal::BlockAccessIndex,
+    DatabaseCommit,
+};
 
 /// Database that tracks the current block-level access list (BAL) index from EIP-7928.
 ///
@@ -27,7 +30,7 @@ where
     Self: Database,
 {
     fn set_bal_index(&mut self, index: u64) {
-        self.bal_state.bal_index = index;
+        self.bal_state.bal_index = BlockAccessIndex::new(index);
     }
 
     fn bump_bal_index(&mut self) {
@@ -40,7 +43,7 @@ where
     Self: Database,
 {
     fn set_bal_index(&mut self, index: u64) {
-        self.bal_state.bal_index = index;
+        self.bal_state.bal_index = BlockAccessIndex::new(index);
     }
 
     fn bump_bal_index(&mut self) {
@@ -63,9 +66,9 @@ mod tests {
         let mut db = State::builder().with_database(CacheDB::new(EmptyDB::new())).build();
 
         BalIndexedDatabase::set_bal_index(&mut db, 7);
-        assert_eq!(db.bal_state.bal_index, 7);
+        assert_eq!(db.bal_state.bal_index, BlockAccessIndex::new(7));
 
         BalIndexedDatabase::bump_bal_index(&mut db);
-        assert_eq!(db.bal_state.bal_index, 8);
+        assert_eq!(db.bal_state.bal_index, BlockAccessIndex::new(8));
     }
 }

--- a/crates/evm/src/block/state_changes.rs
+++ b/crates/evm/src/block/state_changes.rs
@@ -1,7 +1,6 @@
 //! State changes that are not related to transactions.
 
 use super::{calc, BlockExecutionError};
-use alloc::boxed::Box;
 use alloy_consensus::BlockHeader;
 use alloy_eips::eip4895::Withdrawal;
 use alloy_hardforks::EthereumHardforks;
@@ -120,15 +119,9 @@ where
             BlockExecutionError::msg("could not load account for balance increment")
         })?;
 
-        Ok((
-            *address,
-            Account {
-                info: account.clone(),
-                original_info: Box::new(account.clone()),
-                status: AccountStatus::Touched,
-                ..Default::default()
-            },
-        ))
+        let mut new_account = Account::from(account.clone());
+        new_account.status = AccountStatus::Touched;
+        Ok((*address, new_account))
     };
 
     balance_increments

--- a/crates/evm/src/overrides.rs
+++ b/crates/evm/src/overrides.rs
@@ -3,7 +3,7 @@
 //! This module provides helper functions for RPC implementations, including:
 //! - Block and state overrides
 
-use alloc::{boxed::Box, collections::BTreeMap};
+use alloc::collections::BTreeMap;
 use alloy_primitives::{keccak256, map::HashMap, Address, B256, U256};
 use alloy_rpc_types_eth::{
     state::{AccountOverride, StateOverride},
@@ -14,7 +14,7 @@ use revm::{
     context::BlockEnv,
     context_interface::block::BlobExcessGasAndPrice,
     database::{CacheDB, State},
-    state::{Account, AccountStatus, Bytecode, EvmStorageSlot},
+    state::{Account, AccountStatus, Bytecode, EvmStorageSlot, TransactionId},
     Database, DatabaseCommit,
 };
 
@@ -157,13 +157,8 @@ where
     }
 
     // Create a new account marked as touched
-    let mut acc = revm::state::Account {
-        info: info.clone(),
-        original_info: Box::new(info),
-        status: AccountStatus::Touched,
-        storage: Default::default(),
-        transaction_id: 0,
-    };
+    let mut acc = revm::state::Account::from(info);
+    acc.status = AccountStatus::Touched;
 
     let storage_diff = match (account_override.state, account_override.state_diff) {
         (Some(_), Some(_)) => return Err(StateOverrideError::BothStateAndStateDiff(account)),
@@ -173,13 +168,9 @@ where
         // used.
         (Some(state), None) => {
             // Destroy the account to ensure that its storage is cleared
-            db.commit(HashMap::from_iter([(
-                account,
-                Account {
-                    status: AccountStatus::SelfDestructed | AccountStatus::Touched,
-                    ..Default::default()
-                },
-            )]));
+            let mut destroyed = Account::default();
+            destroyed.status = AccountStatus::SelfDestructed | AccountStatus::Touched;
+            db.commit(HashMap::from_iter([(account, destroyed)]));
             // Mark the account as created to ensure that old storage is not read
             acc.mark_created();
             Some(state)
@@ -207,7 +198,7 @@ where
                     original_value: (!value).into(),
                     present_value: value.into(),
                     is_cold: false,
-                    transaction_id: 0,
+                    transaction_id: TransactionId::ZERO,
                 },
             );
         }

--- a/crates/evm/src/precompiles.rs
+++ b/crates/evm/src/precompiles.rs
@@ -3,7 +3,6 @@
 use crate::{Database, EvmInternals};
 use alloc::{
     borrow::Cow,
-    boxed::Box,
     string::{String, ToString},
     sync::Arc,
     vec::Vec,
@@ -566,8 +565,11 @@ where
         Ok(Some(precompile_output_to_interpreter_result(precompile_output, inputs.gas_limit)))
     }
 
-    fn warm_addresses(&self) -> Box<impl Iterator<Item = Address>> {
-        Box::new(self.addresses().copied())
+    fn warm_addresses(&self) -> &AddressSet {
+        match &self.precompiles {
+            PrecompilesKind::Builtin(precompiles) => precompiles.addresses_set(),
+            PrecompilesKind::Dynamic(dyn_precompiles) => &dyn_precompiles.addresses,
+        }
     }
 
     fn contains(&self, address: &Address) -> bool {


### PR DESCRIPTION
## Integration Summary

Patches revm to `bal-devnet-7` and adapts alloy-evm to the new revm APIs.

## Staged Crates

### revm
- **Commit**: `191c163a23569a94097c4f9a7291158183fce256`
- **Changes**:
  - fix(eip8037): unwind grandchild storage-clear refund on revert/halt
  - fix(eip8037): align top-level revert/halt reservoir refund with child-frame rule
  - fix(eip8037): plumb new-account state-gas refund, bump CPSB to 1530, fix clippy

## Fixes Made

- `PrecompileProvider::warm_addresses` now returns `&AddressSet`; switched the `PrecompilesMap` impl to expose the underlying static/dynamic address set instead of an iterator.
- `revm::state::Account::original_info` is now private; construct `Account` via `From<AccountInfo>` (and adjust the `state_changes.rs` and `overrides.rs` call sites accordingly).
- `BalDatabase::set_bal_index` and `State::set_bal_index` now take `BlockAccessIndex`; wrap the incoming `u64` via `BlockAccessIndex::new` in `block/state.rs` and matching test assertions.
- `EvmStorageSlot::transaction_id` is `TransactionId`, not `u64`; switched to `TransactionId::ZERO`.