### PR TITLE
chore: bump revm to 40.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ alloy-rpc-types-eth = { version = "2.0.0", default-features = false }
 alloy-rpc-types-engine = { version = "2.0.0", default-features = false }
 
 # revm
-revm = { version = "38.0.0", default-features = false }
+revm = { version = "40.0.0", default-features = false }
 
 # tracing
 tracing = { version = "0.1", default-features = false }

--- a/crates/evm/src/block/state.rs
+++ b/crates/evm/src/block/state.rs
@@ -1,7 +1,10 @@
 //! State database abstraction.
 
 use crate::Database;
-use revm::{database::State, database_interface::bal::BalDatabase, DatabaseCommit};
+use revm::{
+    database::State, database_interface::bal::BalDatabase, state::bal::BlockAccessIndex,
+    DatabaseCommit,
+};
 
 /// Database that tracks the current block-level access list (BAL) index from EIP-7928.
 ///
@@ -27,7 +30,7 @@ where
     Self: Database,
 {
     fn set_bal_index(&mut self, index: u64) {
-        self.bal_state.bal_index = index;
+        self.bal_state.bal_index = BlockAccessIndex::new(index);
     }
 
     fn bump_bal_index(&mut self) {
@@ -40,7 +43,7 @@ where
     Self: Database,
 {
     fn set_bal_index(&mut self, index: u64) {
-        self.bal_state.bal_index = index;
+        self.bal_state.bal_index = BlockAccessIndex::new(index);
     }
 
     fn bump_bal_index(&mut self) {
@@ -63,9 +66,9 @@ mod tests {
         let mut db = State::builder().with_database(CacheDB::new(EmptyDB::new())).build();
 
         BalIndexedDatabase::set_bal_index(&mut db, 7);
-        assert_eq!(db.bal_state.bal_index, 7);
+        assert_eq!(db.bal_state.bal_index, BlockAccessIndex::new(7));
 
         BalIndexedDatabase::bump_bal_index(&mut db);
-        assert_eq!(db.bal_state.bal_index, 8);
+        assert_eq!(db.bal_state.bal_index, BlockAccessIndex::new(8));
     }
 }

--- a/crates/evm/src/block/state_changes.rs
+++ b/crates/evm/src/block/state_changes.rs
@@ -1,7 +1,6 @@
 //! State changes that are not related to transactions.
 
 use super::{calc, BlockExecutionError};
-use alloc::boxed::Box;
 use alloy_consensus::BlockHeader;
 use alloy_eips::eip4895::Withdrawal;
 use alloy_hardforks::EthereumHardforks;
@@ -120,15 +119,9 @@ where
             BlockExecutionError::msg("could not load account for balance increment")
         })?;
 
-        Ok((
-            *address,
-            Account {
-                info: account.clone(),
-                original_info: Box::new(account.clone()),
-                status: AccountStatus::Touched,
-                ..Default::default()
-            },
-        ))
+        let mut new_account = Account::from(account.clone());
+        new_account.status = AccountStatus::Touched;
+        Ok((*address, new_account))
     };
 
     balance_increments

--- a/crates/evm/src/overrides.rs
+++ b/crates/evm/src/overrides.rs
@@ -3,7 +3,7 @@
 //! This module provides helper functions for RPC implementations, including:
 //! - Block and state overrides
 
-use alloc::{boxed::Box, collections::BTreeMap};
+use alloc::collections::BTreeMap;
 use alloy_primitives::{keccak256, map::HashMap, Address, B256, U256};
 use alloy_rpc_types_eth::{
     state::{AccountOverride, StateOverride},
@@ -14,7 +14,7 @@ use revm::{
     context::BlockEnv,
     context_interface::block::BlobExcessGasAndPrice,
     database::{CacheDB, State},
-    state::{Account, AccountStatus, Bytecode, EvmStorageSlot},
+    state::{Account, AccountStatus, Bytecode, EvmStorageSlot, TransactionId},
     Database, DatabaseCommit,
 };
 
@@ -157,13 +157,8 @@ where
     }
 
     // Create a new account marked as touched
-    let mut acc = revm::state::Account {
-        info: info.clone(),
-        original_info: Box::new(info),
-        status: AccountStatus::Touched,
-        storage: Default::default(),
-        transaction_id: 0,
-    };
+    let mut acc = revm::state::Account::from(info);
+    acc.status = AccountStatus::Touched;
 
     let storage_diff = match (account_override.state, account_override.state_diff) {
         (Some(_), Some(_)) => return Err(StateOverrideError::BothStateAndStateDiff(account)),
@@ -173,13 +168,9 @@ where
         // used.
         (Some(state), None) => {
             // Destroy the account to ensure that its storage is cleared
-            db.commit(HashMap::from_iter([(
-                account,
-                Account {
-                    status: AccountStatus::SelfDestructed | AccountStatus::Touched,
-                    ..Default::default()
-                },
-            )]));
+            let mut destroyed = Account::default();
+            destroyed.status = AccountStatus::SelfDestructed | AccountStatus::Touched;
+            db.commit(HashMap::from_iter([(account, destroyed)]));
             // Mark the account as created to ensure that old storage is not read
             acc.mark_created();
             Some(state)
@@ -207,7 +198,7 @@ where
                     original_value: (!value).into(),
                     present_value: value.into(),
                     is_cold: false,
-                    transaction_id: 0,
+                    transaction_id: TransactionId::ZERO,
                 },
             );
         }

--- a/crates/evm/src/precompiles.rs
+++ b/crates/evm/src/precompiles.rs
@@ -3,7 +3,6 @@
 use crate::{Database, EvmInternals};
 use alloc::{
     borrow::Cow,
-    boxed::Box,
     string::{String, ToString},
     sync::Arc,
     vec::Vec,
@@ -566,8 +565,11 @@ where
         Ok(Some(precompile_output_to_interpreter_result(precompile_output, inputs.gas_limit)))
     }
 
-    fn warm_addresses(&self) -> Box<impl Iterator<Item = Address>> {
-        Box::new(self.addresses().copied())
+    fn warm_addresses(&self) -> &AddressSet {
+        match &self.precompiles {
+            PrecompilesKind::Builtin(precompiles) => precompiles.addresses_set(),
+            PrecompilesKind::Dynamic(dyn_precompiles) => &dyn_precompiles.addresses,
+        }
     }
 
     fn contains(&self, address: &Address) -> bool {


### PR DESCRIPTION
## Summary

Bumps `revm` from `38.0.0` to `40.0.0` (latest published on crates.io).

Adapts to the following breaking changes (using #358 as guideline):
- `BalDatabase::set_bal_index` / `State::set_bal_index` now take `BlockAccessIndex`; wrap incoming `u64` via `BlockAccessIndex::new(...)`.
- `revm::state::Account::original_info` is now private; construct via `Account::from(AccountInfo)` and assign status afterwards.
- `EvmStorageSlot::transaction_id` is now `TransactionId` (use `TransactionId::ZERO` instead of `0`).
- `PrecompileProvider::warm_addresses` now returns `&AddressSet`; `PrecompilesMap` exposes the underlying static (`addresses_set()`) or dynamic address set.

## Test plan

- [x] `cargo build --workspace --all-features`
- [x] `cargo build --workspace --no-default-features` (no_std)
- [x] `cargo test --workspace --all-features` (64 tests pass)
- [x] `cargo clippy --workspace --all-features --all-targets` (clean)