### PR TITLE
docs(evm): clarify executable tx parts

### DIFF
--- a/crates/evm/src/block/mod.rs
+++ b/crates/evm/src/block/mod.rs
@@ -55,7 +55,8 @@ impl<T> Default for BlockExecutionResult<T> {
 /// Helper trait to encapsulate requirements for a type to be used as input for [`BlockExecutor`].
 ///
 /// This trait combines the requirements for a transaction to be executable by a block executor:
-/// - Must be convertible to the EVM's transaction environment
+/// - Must be convertible to the EVM's transaction environment, such as revm's
+///   [`TxEnv`](revm::context::TxEnv)
 /// - Must provide access to the transaction and signer via [`RecoveredTx`]
 ///
 /// The trait ensures that the block executor can both execute the transaction in the EVM
@@ -72,7 +73,8 @@ pub trait ExecutableTxParts<TxEnv, T> {
     /// The recovered transaction accessor type.
     type Recovered: RecoveredTx<T>;
 
-    /// Converts the transaction to an executable environment and a recovered transaction itself.
+    /// Converts the transaction into the executable transaction environment (`TxEnv`) and the
+    /// original recovered transaction.
     fn into_parts(self) -> (TxEnv, Self::Recovered);
 }
 


### PR DESCRIPTION
## Summary

Clarifies the `ExecutableTxParts` docs so `into_parts` is explicit about returning the executable transaction environment (`TxEnv`) together with the original recovered transaction.

The docs now call out revm's `TxEnv` as the concrete example of the transaction environment used by block execution.

## Impact

This is a documentation-only change intended to make the transaction conversion contract easier to understand for implementers and downstream users.