### PR TITLE
fix: dispatch proper balance increments state to state hook

### DIFF
--- a/crates/evm/src/block/state_changes.rs
+++ b/crates/evm/src/block/state_changes.rs
@@ -102,7 +102,6 @@ pub fn insert_post_block_withdrawals_balance_increments(
 
 /// Creates an `EvmState` from a map of balance increments and the current state
 /// to load accounts from. No balance increment is done in the function.
-/// Zero balance increments are ignored and won't create state entries.
 pub(crate) fn balance_increment_state<DB>(
     balance_increments: &AddressMap<u128>,
     state: &mut DB,

--- a/crates/evm/src/block/state_changes.rs
+++ b/crates/evm/src/block/state_changes.rs
@@ -4,10 +4,10 @@ use super::{calc, BlockExecutionError};
 use alloy_consensus::BlockHeader;
 use alloy_eips::eip4895::Withdrawal;
 use alloy_hardforks::EthereumHardforks;
-use alloy_primitives::{map::AddressMap, Address};
+use alloy_primitives::{map::AddressMap, U256};
 use revm::{
     context::Block,
-    state::{Account, AccountStatus, EvmState},
+    state::{Account, EvmState, TransactionId},
     Database,
 };
 
@@ -110,23 +110,19 @@ pub fn balance_increment_state<DB>(
 where
     DB: Database,
 {
-    let mut load_account = |address: &Address| -> Result<(Address, Account), BlockExecutionError> {
-        let cache_account = state.basic(*address).map_err(|_| {
-            BlockExecutionError::msg("could not load account for balance increment")
-        })?;
-
-        let account = cache_account.as_ref().ok_or_else(|| {
-            BlockExecutionError::msg("could not load account for balance increment")
-        })?;
-
-        let mut new_account = Account::from(account.clone());
-        new_account.status = AccountStatus::Touched;
-        Ok((*address, new_account))
-    };
-
     balance_increments
         .iter()
-        .filter(|(_, &balance)| balance != 0)
-        .map(|(addr, _)| load_account(addr))
+        .map(|(address, &balance)| {
+            let cache_account = state.basic(*address).map_err(|_| {
+                BlockExecutionError::msg("could not load account for balance increment")
+            })?;
+
+            let mut new_account = cache_account
+                .map(Account::from)
+                .unwrap_or_else(|| Account::new_not_existing(TransactionId::ZERO));
+            new_account.info.balance = new_account.info.balance.saturating_add(U256::from(balance));
+            new_account.mark_touch();
+            Ok((*address, new_account))
+        })
         .collect::<Result<EvmState, _>>()
 }

--- a/crates/evm/src/block/state_changes.rs
+++ b/crates/evm/src/block/state_changes.rs
@@ -103,7 +103,7 @@ pub fn insert_post_block_withdrawals_balance_increments(
 /// Creates an `EvmState` from a map of balance increments and the current state
 /// to load accounts from. No balance increment is done in the function.
 /// Zero balance increments are ignored and won't create state entries.
-pub fn balance_increment_state<DB>(
+pub(crate) fn balance_increment_state<DB>(
     balance_increments: &AddressMap<u128>,
     state: &mut DB,
 ) -> Result<EvmState, BlockExecutionError>

--- a/crates/evm/src/block/state_changes.rs
+++ b/crates/evm/src/block/state_changes.rs
@@ -100,8 +100,8 @@ pub fn insert_post_block_withdrawals_balance_increments(
     }
 }
 
-/// Creates an `EvmState` from a map of balance increments and the current state
-/// to load accounts from. No balance increment is done in the function.
+/// Creates an [`EvmState`] from a map of balance increments and the current state. Loads accounts
+/// from the database and applies increments on top of their state.
 pub(crate) fn balance_increment_state<DB>(
     balance_increments: &AddressMap<u128>,
     state: &mut DB,

--- a/crates/evm/src/eth/block.rs
+++ b/crates/evm/src/eth/block.rs
@@ -288,11 +288,12 @@ where
             *balance_increments.entry(dao_fork::DAO_HARDFORK_BENEFICIARY).or_default() +=
                 drained_balance;
         }
+        // increment balances
         let balance_increment_state =
             balance_increment_state(&balance_increments, self.evm.db_mut())
                 .map_err(|_| BlockValidationError::IncrementBalanceFailed)?;
 
-        // Call state hook with the same balance increment state that will be committed.
+        // call state hook with changes due to balance increments.
         self.system_caller.on_state(
             StateChangeSource::PostBlock(StateChangePostBlockSource::BalanceIncrements),
             &balance_increment_state,

--- a/crates/evm/src/eth/block.rs
+++ b/crates/evm/src/eth/block.rs
@@ -288,21 +288,17 @@ where
             *balance_increments.entry(dao_fork::DAO_HARDFORK_BENEFICIARY).or_default() +=
                 drained_balance;
         }
-        // increment balances
-        self.evm
-            .db_mut()
-            .increment_balances(balance_increments.clone())
-            .map_err(|_| BlockValidationError::IncrementBalanceFailed)?;
+        let balance_increment_state =
+            balance_increment_state(&balance_increments, self.evm.db_mut())
+                .map_err(|_| BlockValidationError::IncrementBalanceFailed)?;
 
-        // call state hook with changes due to balance increments.
-        self.system_caller.try_on_state_with(|| {
-            balance_increment_state(&balance_increments, self.evm.db_mut()).map(|state| {
-                (
-                    StateChangeSource::PostBlock(StateChangePostBlockSource::BalanceIncrements),
-                    Cow::Owned(state),
-                )
-            })
-        })?;
+        // Call state hook with the same balance increment state that will be committed.
+        self.system_caller.on_state(
+            StateChangeSource::PostBlock(StateChangePostBlockSource::BalanceIncrements),
+            &balance_increment_state,
+        );
+
+        self.evm.db_mut().commit(balance_increment_state);
 
         // Pre-Amsterdam: use tx_gas_used (with refunds) for the block gas total.
         // Amsterdam+: use max(regular, state) gas without refunds (EIP-8037).


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Right now the state produced by `balance_increment_state` and dispatched to state hook contains wrong `original_info`. At the moment it doesn't present an issue for reth but it'd be easier to implement some optimizations if this value was right.

This PR fixes the `balance_increment_state` to produce correct state and uses it as both state hook input and the commited value. `balance_increment_state` visibility is changed to avoid misuse as its behavior is slightly different now

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
