### PR TITLE
feat: handle non-fatal EVM errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ alloy-rpc-types-eth = { version = "2.0.0", default-features = false }
 alloy-rpc-types-engine = { version = "2.0.0", default-features = false }
 
 # revm
-revm = { version = "40.0.0", default-features = false }
+revm = { version = "40.0.2", default-features = false }
 
 # tracing
 tracing = { version = "0.1", default-features = false }

--- a/crates/evm/src/block/error.rs
+++ b/crates/evm/src/block/error.rs
@@ -160,13 +160,16 @@ impl BlockExecutionError {
     /// Handles an EVM error occurred when executing a transaction.
     ///
     /// If an error matches [`EvmError::InvalidTransaction`], it will be wrapped into
-    /// [`BlockValidationError::InvalidTx`], otherwise into [`InternalBlockExecutionError::EVM`].
+    /// [`BlockValidationError::InvalidTx`], otherwise if [`EvmError::is_fatal`] return `true`, the
+    /// error would be wrapped into [`InternalBlockExecutionError::EVM`], otherwise it would be
+    /// wrapped into [`BlockValidationError::EVM`].
     pub fn evm<E: EvmError>(error: E, hash: B256) -> Self {
         match error.try_into_invalid_tx_err() {
             Ok(err) => {
                 Self::Validation(BlockValidationError::InvalidTx { hash, error: Box::new(err) })
             }
             Err(err) => {
+                // Route errors based on whether they are fatal or not.
                 if err.is_fatal() {
                     Self::Internal(InternalBlockExecutionError::EVM { hash, error: Box::new(err) })
                 } else {

--- a/crates/evm/src/block/error.rs
+++ b/crates/evm/src/block/error.rs
@@ -4,6 +4,7 @@ use alloc::{
     string::{String, ToString},
 };
 use alloy_primitives::B256;
+use core::error::Error;
 
 /// Block validation error.
 #[derive(Debug, thiserror::Error)]
@@ -15,6 +16,15 @@ pub enum BlockValidationError {
         hash: B256,
         /// The EVM error.
         error: Box<dyn InvalidTxError>,
+    },
+    /// EVM error that is not a transaction validation error. Most likely a BAL error propagated
+    /// from the database.
+    #[error("EVM execution failed: {error}")]
+    EVM {
+        /// The hash of the transaction
+        hash: B256,
+        /// The EVM error.
+        error: Box<dyn Error + Send + Sync + 'static>,
     },
     /// Error when incrementing balance in post execution
     #[error("incrementing balance in post execution failed")]
@@ -157,7 +167,11 @@ impl BlockExecutionError {
                 Self::Validation(BlockValidationError::InvalidTx { hash, error: Box::new(err) })
             }
             Err(err) => {
-                Self::Internal(InternalBlockExecutionError::EVM { hash, error: Box::new(err) })
+                if err.is_fatal() {
+                    Self::Internal(InternalBlockExecutionError::EVM { hash, error: Box::new(err) })
+                } else {
+                    Self::Validation(BlockValidationError::EVM { hash, error: Box::new(err) })
+                }
             }
         }
     }
@@ -257,11 +271,16 @@ impl InternalBlockExecutionError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use revm::context_interface::result::{EVMError, InvalidTransaction};
+    use revm::{
+        context::DBErrorMarker,
+        context_interface::result::{EVMError, InvalidTransaction},
+    };
 
     #[derive(thiserror::Error, Debug)]
     #[error("err")]
     struct E;
+
+    impl DBErrorMarker for E {}
 
     #[test]
     fn other_downcast() {

--- a/crates/evm/src/error.rs
+++ b/crates/evm/src/error.rs
@@ -1,7 +1,10 @@
 //! Abstraction over EVM errors.
 
 use core::{any::Any, error::Error};
-use revm::context_interface::result::{EVMError, InvalidTransaction};
+use revm::{
+    context::DBErrorMarker,
+    context_interface::result::{EVMError, InvalidTransaction},
+};
 
 /// Abstraction over transaction validation error.
 pub trait InvalidTxError: Error + Send + Sync + Any + 'static {
@@ -64,6 +67,10 @@ pub trait EvmError: Sized + Error + Send + Sync + 'static {
     /// Attempts to convert the error into [`EvmError::InvalidTransaction`].
     fn try_into_invalid_tx_err(self) -> Result<Self::InvalidTransaction, Self>;
 
+    /// Returns `true` if the error is fatal and should be treated as an internal error during
+    /// execution.
+    fn is_fatal(&self) -> bool;
+
     /// Returns `true` if the error is an invalid transaction error.
     fn is_invalid_tx_err(&self) -> bool {
         self.as_invalid_tx_err().is_some()
@@ -72,7 +79,7 @@ pub trait EvmError: Sized + Error + Send + Sync + 'static {
 
 impl<DBError, TxError> EvmError for EVMError<DBError, TxError>
 where
-    DBError: Error + Send + Sync + 'static,
+    DBError: DBErrorMarker,
     TxError: InvalidTxError,
 {
     type InvalidTransaction = TxError;
@@ -88,6 +95,14 @@ where
         match self {
             Self::Transaction(err) => Ok(err),
             err => Err(err),
+        }
+    }
+
+    fn is_fatal(&self) -> bool {
+        match self {
+            Self::Transaction(_) => false,
+            Self::Custom(_) | Self::CustomAny(_) | Self::Header(_) => true,
+            Self::Database(err) => err.is_fatal(),
         }
     }
 }

--- a/crates/evm/src/eth/mod.rs
+++ b/crates/evm/src/eth/mod.rs
@@ -9,7 +9,7 @@ use core::{
     ops::{Deref, DerefMut},
 };
 use revm::{
-    context::{BlockEnv, CfgEnv, Evm as RevmEvm, TxEnv},
+    context::{BlockEnv, CfgEnv, DBErrorMarker, Evm as RevmEvm, TxEnv},
     context_interface::result::{EVMError, HaltReason, ResultAndState},
     handler::{instructions::EthInstructions, EthFrame, EthPrecompiles, PrecompileProvider},
     inspector::NoOpInspector,
@@ -271,7 +271,7 @@ impl EvmFactory for EthEvmFactory {
     type Evm<DB: Database, I: Inspector<EthEvmContext<DB>>> = EthEvm<DB, I, Self::Precompiles>;
     type Context<DB: Database> = Context<BlockEnv, TxEnv, CfgEnv, DB>;
     type Tx = TxEnv;
-    type Error<DBError: core::error::Error + Send + Sync + 'static> = EVMError<DBError>;
+    type Error<DBError: DBErrorMarker> = EVMError<DBError>;
     type HaltReason = HaltReason;
     type Spec = SpecId;
     type BlockEnv = BlockEnv;

--- a/crates/evm/src/evm.rs
+++ b/crates/evm/src/evm.rs
@@ -5,7 +5,7 @@ use alloy_consensus::transaction::TxHashRef;
 use alloy_primitives::{Address, Bytes, B256};
 use core::{error::Error, fmt::Debug, hash::Hash};
 use revm::{
-    context::{result::ExecutionResult, CfgEnv},
+    context::{result::ExecutionResult, CfgEnv, DBErrorMarker},
     context_interface::{
         result::{HaltReasonTr, ResultAndState},
         ContextTr,
@@ -274,7 +274,7 @@ pub trait EvmFactory {
     /// Transaction environment.
     type Tx: IntoTxEnv<Self::Tx>;
     /// EVM error. See [`Evm::Error`].
-    type Error<DBError: Error + Send + Sync + 'static>: EvmError;
+    type Error<DBError: DBErrorMarker>: EvmError;
     /// Halt reason. See [`Evm::HaltReason`].
     type HaltReason: HaltReasonTr + Send + Sync + 'static;
     /// The EVM specification identifier, see [`Evm::Spec`].


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Adds support for non-fatal database errors like the ones returned from BAL database. Those errors are now mapped to `BlockValidationError` variant, allowing to not fail entire block's execution

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
