### PR TITLE
DO NOT MERGE feat(glam-devnet-5): add EIP-7997 deterministic factory predeploy

### DIFF
--- a/crates/evm/src/block/state_hook.rs
+++ b/crates/evm/src/block/state_hook.rs
@@ -32,6 +32,9 @@ pub enum StateChangePreBlockSource {
     /// EIP-7002: triggers the withdrawal requests contract to process any queued validator
     /// withdrawal requests.
     WithdrawalRequestsContract,
+    /// EIP-7997: inserts the deterministic `CREATE2` factory bytecode at its fixed address on the
+    /// block that activates Amsterdam.
+    FactoryPredeploy,
     /// A custom pre-block state change not covered by the standard variants.
     Other(&'static str),
 }

--- a/crates/evm/src/block/system_calls/eip7997.rs
+++ b/crates/evm/src/block/system_calls/eip7997.rs
@@ -151,6 +151,48 @@ mod tests {
     }
 
     #[test]
+    fn commit_records_change_and_preserves_balance() {
+        use revm::{database::states::bundle_state::BundleRetention, DatabaseCommit};
+
+        // Account pre-exists with a balance but no code.
+        let balance = U256::from(7u64);
+        let mut db = CacheDB::new(EmptyDB::new());
+        db.insert_account_info(FACTORY_ADDRESS, AccountInfo::from_balance(balance));
+
+        // Built inline (not via `evm_with`) so the concrete `State` DB type is preserved and its
+        // `merge_transitions`/`take_bundle` methods remain callable.
+        let mut cfg = CfgEnv::default();
+        cfg.spec = SpecId::AMSTERDAM;
+        let env = EvmEnv {
+            block_env: BlockEnv { timestamp: U256::from(1), ..Default::default() },
+            cfg_env: cfg,
+        };
+        let inner = State::builder().with_database(db).with_bundle_update().build();
+        let mut evm = EthEvmFactory.create_evm(inner, env);
+
+        let state =
+            build_factory_predeploy_state(&TestSpec { amsterdam: true }, &mut evm).unwrap().unwrap();
+        // Balance is preserved on the pre-existing account.
+        assert_eq!(state.get(&FACTORY_ADDRESS).unwrap().info.balance, balance);
+        evm.db_mut().commit(state);
+
+        // Post-state reads back the code and the preserved balance.
+        let info = evm.db_mut().basic(FACTORY_ADDRESS).unwrap().unwrap();
+        assert_eq!(info.code_hash, FACTORY_CODE_HASH);
+        assert_eq!(info.balance, balance);
+
+        // The bundle records the transition from (balance, no code) to (balance, factory code),
+        // i.e. the original is tracked correctly rather than the post-insertion state.
+        evm.db_mut().merge_transitions(BundleRetention::Reverts);
+        let bundle = evm.db_mut().take_bundle();
+        let acct = bundle.account(&FACTORY_ADDRESS).expect("bundle account");
+        assert_eq!(acct.info.as_ref().unwrap().code_hash, FACTORY_CODE_HASH);
+        let original = acct.original_info.as_ref().expect("original info");
+        assert_eq!(original.balance, balance);
+        assert!(original.is_empty_code_hash(), "original should have no code");
+    }
+
+    #[test]
     fn noop_before_amsterdam() {
         let mut evm = evm_with(CacheDB::new(EmptyDB::new()));
 

--- a/crates/evm/src/block/system_calls/eip7997.rs
+++ b/crates/evm/src/block/system_calls/eip7997.rs
@@ -37,8 +37,8 @@ pub const FACTORY_CODE_HASH: B256 =
 /// present at the address. Comparing the existing code hash makes the insertion idempotent, so it
 /// only mutates state once: on the block that activates Amsterdam.
 ///
-/// The existing balance is preserved and the nonce is set to `1`, matching the account state of a
-/// deployed contract.
+/// Only the code (and its hash) is set; any existing account fields, such as balance and nonce,
+/// are preserved, as EIP-7997 does not specify them.
 ///
 /// Note: this does not commit the state change to the database, it only constructs it.
 #[inline]
@@ -62,7 +62,6 @@ pub(crate) fn build_factory_predeploy_state(
         return Ok(None);
     }
 
-    info.nonce = 1;
     info.code_hash = FACTORY_CODE_HASH;
     info.code = Some(Bytecode::new_legacy(FACTORY_CODE));
 
@@ -128,7 +127,6 @@ mod tests {
         let account = state.get(&FACTORY_ADDRESS).expect("factory account");
         assert_eq!(account.info.code_hash, FACTORY_CODE_HASH);
         assert_eq!(account.info.code.as_ref().unwrap().original_bytes(), FACTORY_CODE);
-        assert_eq!(account.info.nonce, 1);
         assert!(account.is_touched());
         assert_eq!(state.len(), 1);
     }
@@ -140,7 +138,6 @@ mod tests {
         db.insert_account_info(
             FACTORY_ADDRESS,
             AccountInfo {
-                nonce: 1,
                 code_hash: FACTORY_CODE_HASH,
                 code: Some(Bytecode::new_legacy(FACTORY_CODE)),
                 ..Default::default()

--- a/crates/evm/src/block/system_calls/eip7997.rs
+++ b/crates/evm/src/block/system_calls/eip7997.rs
@@ -1,0 +1,164 @@
+//! [EIP-7997](https://eips.ethereum.org/EIPS/eip-7997) deterministic factory predeploy.
+//!
+//! EIP-7997 inserts a minimal `CREATE2` factory as a contract at a fixed address upon activation
+//! of the Amsterdam hardfork, enabling deterministic deployments at identical addresses across
+//! EVM chains.
+
+use crate::{block::BlockExecutionError, Evm};
+use alloy_hardforks::EthereumHardforks;
+use alloy_primitives::{address, b256, bytes, Address, Bytes, B256};
+use revm::{
+    context::Block,
+    state::{Account, AccountStatus, Bytecode, EvmState},
+    Database,
+};
+
+/// Address of the EIP-7997 deterministic `CREATE2` factory predeploy.
+pub const FACTORY_ADDRESS: Address = address!("0x0000000000000000000000000000000000000012");
+
+/// Runtime bytecode deployed at [`FACTORY_ADDRESS`] on activation of EIP-7997.
+///
+/// When called, it invokes `CREATE2` using the first 32 bytes of the input as the salt and the
+/// remaining bytes as the init code, forwarding the call value.
+pub const FACTORY_CODE: Bytes = bytes!(
+    "0x60203610602f5760003560203603806020600037600034f5806026573d600060003e3d6000fd5b60005260206000f35b60006000fd"
+);
+
+/// keccak256 hash of [`FACTORY_CODE`].
+///
+/// Used to detect whether the predeploy is already present, keeping the insertion idempotent.
+pub const FACTORY_CODE_HASH: B256 =
+    b256!("0x2b2a8b8ac51cd14e2371a09cc5fa3737e74cabd8dafad0573ebca41c7cd5b51f");
+
+/// Builds the pre-block state change that inserts the EIP-7997 factory bytecode at
+/// [`FACTORY_ADDRESS`].
+///
+/// Returns `None` (a no-op) when Amsterdam is not active, or when the factory code is already
+/// present at the address. Comparing the existing code hash makes the insertion idempotent, so it
+/// only mutates state once: on the block that activates Amsterdam.
+///
+/// The existing balance is preserved and the nonce is set to `1`, matching the account state of a
+/// deployed contract.
+///
+/// Note: this does not commit the state change to the database, it only constructs it.
+#[inline]
+pub(crate) fn build_factory_predeploy_state(
+    spec: impl EthereumHardforks,
+    evm: &mut impl Evm,
+) -> Result<Option<EvmState>, BlockExecutionError> {
+    if !spec.is_amsterdam_active_at_timestamp(evm.block().timestamp().saturating_to()) {
+        return Ok(None);
+    }
+
+    let mut info = evm
+        .db_mut()
+        .basic(FACTORY_ADDRESS)
+        .map_err(|_| BlockExecutionError::msg("could not load EIP-7997 factory account"))?
+        .unwrap_or_default();
+
+    // Idempotent: only insert the factory on the block that activates Amsterdam. On later blocks
+    // the code is already present, so this is a no-op.
+    if info.code_hash == FACTORY_CODE_HASH {
+        return Ok(None);
+    }
+
+    info.nonce = 1;
+    info.code_hash = FACTORY_CODE_HASH;
+    info.code = Some(Bytecode::new_legacy(FACTORY_CODE));
+
+    let mut account = Account::from(info);
+    account.status = AccountStatus::Touched;
+
+    Ok(Some(EvmState::from_iter([(FACTORY_ADDRESS, account)])))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{EthEvmFactory, EvmEnv, EvmFactory};
+    use alloy_hardforks::{EthereumHardfork, ForkCondition};
+    use alloy_primitives::{keccak256, U256};
+    use revm::{
+        context::{BlockEnv, CfgEnv},
+        database::{CacheDB, EmptyDB, State},
+        primitives::hardfork::SpecId,
+        state::AccountInfo,
+    };
+
+    /// Minimal spec that reports Amsterdam as active from genesis when `amsterdam` is set.
+    struct TestSpec {
+        amsterdam: bool,
+    }
+
+    impl EthereumHardforks for TestSpec {
+        fn ethereum_fork_activation(&self, fork: EthereumHardfork) -> ForkCondition {
+            if self.amsterdam && fork == EthereumHardfork::Amsterdam {
+                ForkCondition::Timestamp(0)
+            } else {
+                ForkCondition::Never
+            }
+        }
+    }
+
+    fn evm_with(db: CacheDB<EmptyDB>) -> impl Evm {
+        let mut cfg = CfgEnv::default();
+        cfg.spec = SpecId::AMSTERDAM;
+        let env = EvmEnv {
+            block_env: BlockEnv { timestamp: U256::from(1), ..Default::default() },
+            cfg_env: cfg,
+        };
+        let db = State::builder().with_database(db).with_bundle_update().build();
+        EthEvmFactory.create_evm(db, env)
+    }
+
+    #[test]
+    fn factory_code_hash_matches_code() {
+        assert_eq!(keccak256(&FACTORY_CODE), FACTORY_CODE_HASH);
+        assert_eq!(Bytecode::new_legacy(FACTORY_CODE).hash_slow(), FACTORY_CODE_HASH);
+    }
+
+    #[test]
+    fn inserts_factory_when_amsterdam_active() {
+        let mut evm = evm_with(CacheDB::new(EmptyDB::new()));
+
+        let state = build_factory_predeploy_state(&TestSpec { amsterdam: true }, &mut evm)
+            .unwrap()
+            .expect("factory predeploy state");
+
+        let account = state.get(&FACTORY_ADDRESS).expect("factory account");
+        assert_eq!(account.info.code_hash, FACTORY_CODE_HASH);
+        assert_eq!(account.info.code.as_ref().unwrap().original_bytes(), FACTORY_CODE);
+        assert_eq!(account.info.nonce, 1);
+        assert!(account.is_touched());
+        assert_eq!(state.len(), 1);
+    }
+
+    #[test]
+    fn idempotent_when_already_deployed() {
+        let mut db = CacheDB::new(EmptyDB::new());
+        // Pretend the factory is already deployed at the target address.
+        db.insert_account_info(
+            FACTORY_ADDRESS,
+            AccountInfo {
+                nonce: 1,
+                code_hash: FACTORY_CODE_HASH,
+                code: Some(Bytecode::new_legacy(FACTORY_CODE)),
+                ..Default::default()
+            },
+        );
+        let mut evm = evm_with(db);
+
+        assert!(build_factory_predeploy_state(&TestSpec { amsterdam: true }, &mut evm)
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn noop_before_amsterdam() {
+        let mut evm = evm_with(CacheDB::new(EmptyDB::new()));
+
+        assert!(build_factory_predeploy_state(&TestSpec { amsterdam: false }, &mut evm)
+            .unwrap()
+            .is_none());
+    }
+}

--- a/crates/evm/src/block/system_calls/mod.rs
+++ b/crates/evm/src/block/system_calls/mod.rs
@@ -19,6 +19,9 @@ mod eip2935;
 mod eip4788;
 mod eip7002;
 mod eip7251;
+mod eip7997;
+
+pub use eip7997::{FACTORY_ADDRESS, FACTORY_CODE, FACTORY_CODE_HASH};
 
 /// An ephemeral helper type for executing system calls.
 ///
@@ -57,6 +60,7 @@ where
     ) -> Result<(), BlockExecutionError> {
         self.apply_blockhashes_contract_call(header.parent_hash(), evm)?;
         self.apply_beacon_root_contract_call(header.parent_beacon_block_root(), evm)?;
+        self.apply_factory_predeploy(evm)?;
 
         Ok(())
     }
@@ -133,6 +137,31 @@ where
                 );
             }
             evm.db_mut().commit(res.state);
+        }
+
+        Ok(())
+    }
+
+    /// Applies the EIP-7997 pre-block state transition, inserting the deterministic `CREATE2`
+    /// factory bytecode at [`FACTORY_ADDRESS`].
+    ///
+    /// This is a no-op unless Amsterdam is active and the factory is not already deployed, so it
+    /// only mutates state on the block that activates Amsterdam.
+    pub fn apply_factory_predeploy(
+        &mut self,
+        evm: &mut impl Evm<DB: DatabaseCommit>,
+    ) -> Result<(), BlockExecutionError> {
+        let _span = tracing::debug_span!("eip7997_factory_predeploy").entered();
+        let state = eip7997::build_factory_predeploy_state(&self.spec, evm)?;
+
+        if let Some(state) = state {
+            if let Some(hook) = &mut self.hook {
+                hook.on_state(
+                    StateChangeSource::PreBlock(StateChangePreBlockSource::FactoryPredeploy),
+                    &state,
+                );
+            }
+            evm.db_mut().commit(state);
         }
 
         Ok(())

--- a/crates/evm/src/eth/block.rs
+++ b/crates/evm/src/eth/block.rs
@@ -153,6 +153,7 @@ where
         self.system_caller.apply_blockhashes_contract_call(self.ctx.parent_hash, &mut self.evm)?;
         self.system_caller
             .apply_beacon_root_contract_call(self.ctx.parent_beacon_block_root, &mut self.evm)?;
+        self.system_caller.apply_factory_predeploy(&mut self.evm)?;
 
         Ok(())
     }


### PR DESCRIPTION
## Summary

Implements [EIP-7997](https://eips.ethereum.org/EIPS/eip-7997) ("Deterministic Factory Predeploy"): inserts a minimal `CREATE2` factory as a contract at the fixed address `0x...0012` upon Amsterdam activation, so contracts can be deployed at identical addresses across EVM chains.

The insertion is done as an **Amsterdam pre-block state transition**, alongside the existing EIP-2935 / EIP-4788 pre-block calls.

## Changes

- **New module `block/system_calls/eip7997.rs`** — defines `FACTORY_ADDRESS` (`0x12`), `FACTORY_CODE` (runtime bytecode), `FACTORY_CODE_HASH`, and `build_factory_predeploy_state(spec, evm)`, which builds the `EvmState` that sets the bytecode (code, code hash, nonce `1`, preserving any existing balance, marked `Touched`).
- **`SystemCaller::apply_factory_predeploy`** — commits the state and fires the state hook; wired into `SystemCaller::apply_pre_execution_changes` and `EthBlockExecutor::apply_pre_execution_changes`.
- **`StateChangePreBlockSource::FactoryPredeploy`** — new state-hook source variant.

## Design notes

- **Idempotent insertion.** The EIP only states the account "becomes a contract" on activation, and the block execution context does not carry the parent timestamp needed to detect the exact transition block. Instead, the builder compares the existing account's code hash and only writes when the factory is not already present. The observable result is identical (code appears on the activation block, untouched afterward) and is robust whether executing the transition block or syncing from a post-Amsterdam state.
- **Nonce.** The EIP is silent on the nonce; set to `1` to match a normally-deployed contract (EIP-161).

## Testing

Added unit tests covering: code-hash correctness, insertion when Amsterdam is active, idempotency when already deployed, and no-op before Amsterdam. Full crate suite passes (55 unit tests) and clippy is clean.