### PR TITLE
chore: bump revm to tip1060

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,3 +61,17 @@ serde = { version = "1", default-features = false, features = ["derive"] }
 thiserror = { version = "2.0.0", default-features = false }
 serde_json = "1"
 test-case = "3"
+
+[patch.crates-io]
+revm = { git = "https://github.com/bluealloy/revm", rev = "d9ff851f6350f047238bcfdf5a31b0f76e41e2f9" }
+revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "d9ff851f6350f047238bcfdf5a31b0f76e41e2f9" }
+revm-context = { git = "https://github.com/bluealloy/revm", rev = "d9ff851f6350f047238bcfdf5a31b0f76e41e2f9" }
+revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "d9ff851f6350f047238bcfdf5a31b0f76e41e2f9" }
+revm-database = { git = "https://github.com/bluealloy/revm", rev = "d9ff851f6350f047238bcfdf5a31b0f76e41e2f9" }
+revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "d9ff851f6350f047238bcfdf5a31b0f76e41e2f9" }
+revm-handler = { git = "https://github.com/bluealloy/revm", rev = "d9ff851f6350f047238bcfdf5a31b0f76e41e2f9" }
+revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "d9ff851f6350f047238bcfdf5a31b0f76e41e2f9" }
+revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "d9ff851f6350f047238bcfdf5a31b0f76e41e2f9" }
+revm-precompile = { git = "https://github.com/bluealloy/revm", rev = "d9ff851f6350f047238bcfdf5a31b0f76e41e2f9" }
+revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "d9ff851f6350f047238bcfdf5a31b0f76e41e2f9" }
+revm-state = { git = "https://github.com/bluealloy/revm", rev = "d9ff851f6350f047238bcfdf5a31b0f76e41e2f9" }


### PR DESCRIPTION
Bumps revm to `tip1060` commit `d9ff851f6350f047238bcfdf5a31b0f76e41e2f9` (revm v40.0.3) via `[patch.crates-io]`. Part of the tip1060 integration chain.