### PR TITLE
fix(ci): ignore proc-macro-error2 advisory

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -6,6 +6,9 @@ ignore = [
     "RUSTSEC-2024-0437",
     # https://rustsec.org/advisories/RUSTSEC-2024-0436
     "RUSTSEC-2024-0436",
+    # https://rustsec.org/advisories/RUSTSEC-2026-0173
+    # alloy-sol-macro dependency, no fix available yet
+    "RUSTSEC-2026-0173",
 ]
 
 [bans]


### PR DESCRIPTION
## Summary

Adds `RUSTSEC-2026-0173` to the cargo-deny advisory ignore list for the transitive `proc-macro-error2` dependency.

## Root Cause

The deny job started failing because RustSec now marks `proc-macro-error2 v2.0.1` as unmaintained. It is pulled in through `alloy-sol-macro v1.6.0`, and the advisory reports that no safe upgrade is currently available.

## Impact

Restores the cargo-deny advisory check while keeping the exception explicit and scoped to the current transitive dependency.