### PR TITLE
chore: bump revm to 41.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ alloy-rpc-types-eth = { version = "2.0.0", default-features = false }
 alloy-rpc-types-engine = { version = "2.0.0", default-features = false }
 
 # revm
-revm = { version = "40.0.3", default-features = false }
+revm = { version = "41.0.0", default-features = false }
 
 # tracing
 tracing = { version = "0.1", default-features = false }


### PR DESCRIPTION
Bumps revm from 40.0.3 to 41.0.0.

Workspace compiles with `--all-features` and all tests pass with no code changes required.