### PR TITLE
feat: add EthBlockExecutor reserve

### DIFF
--- a/crates/evm/src/eth/block.rs
+++ b/crates/evm/src/eth/block.rs
@@ -126,6 +126,12 @@ where
         }
     }
 
+    /// Reserves capacity for at least `tx_count` additional receipts.
+    #[inline]
+    pub fn reserve(&mut self, tx_count: usize) {
+        self.receipts.reserve(tx_count);
+    }
+
     /// Returns the maximum of regular and state gas used by transactions in this block.
     #[inline]
     pub const fn max_block_gas_used(&self) -> u64 {


### PR DESCRIPTION
## Summary

Adds `EthBlockExecutor::reserve(tx_count)` so callers can reserve receipt capacity after executor construction.

## Impact

This forwards to the executor internal receipts vector, matching the existing `tx_count_hint` preallocation behavior while allowing callers to reserve capacity explicitly when the transaction count is known later.