### PR TITLE
Expose dyn BlockEnvironment in EvmInternals

### DIFF
--- a/crates/evm/src/env.rs
+++ b/crates/evm/src/env.rs
@@ -298,15 +298,6 @@ mod tests {
     }
 
     #[test]
-    fn test_dyn_block_environment_downcasts_to_block_env() {
-        let block_env = BlockEnv::default();
-        let dyn_block_env: &dyn BlockEnvironment = &block_env;
-        let any_block_env = dyn_block_env as &dyn Any;
-
-        assert!(any_block_env.downcast_ref::<BlockEnv>().is_some());
-    }
-
-    #[test]
     fn test_evm_env_with_osaka_limits() {
         // osaka() has tx_gas_limit_cap set to EIP-7825's cap.
         use revm::context::{BlockEnv, CfgEnv};

--- a/crates/evm/src/env.rs
+++ b/crates/evm/src/env.rs
@@ -1,6 +1,6 @@
 //! Configuration types for EVM environment.
 
-use core::fmt::Debug;
+use core::{any::Any, fmt::Debug};
 
 use alloy_primitives::U256;
 use revm::{
@@ -162,7 +162,7 @@ impl<Spec, BlockEnv> From<(CfgEnv<Spec>, BlockEnv)> for EvmEnv<Spec, BlockEnv> {
 /// Trait for types that can be used as a block environment.
 ///
 /// Assumes that the type wraps an inner [`revm::context::BlockEnv`].
-pub trait BlockEnvironment: revm::context::Block + Clone + Debug + Send + Sync + 'static {
+pub trait BlockEnvironment: revm::context::Block + Any + Debug + Send + Sync + 'static {
     /// Returns a mutable reference to the inner [`revm::context::BlockEnv`].
     fn inner_mut(&mut self) -> &mut revm::context::BlockEnv;
 }
@@ -258,7 +258,7 @@ impl EvmLimitParams {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use revm::context::Cfg;
+    use revm::context::{Block, Cfg};
 
     #[test]
     fn test_evm_env_with_limits() {
@@ -287,6 +287,14 @@ mod tests {
             revm::primitives::eip3860::MAX_INITCODE_SIZE
         );
         assert_eq!(evm_env.cfg_env.tx_gas_limit_cap(), revm::primitives::eip7825::TX_GAS_LIMIT_CAP);
+    }
+
+    #[test]
+    fn test_block_environment_is_dyn_compatible() {
+        let block_env = BlockEnv::default();
+        let dyn_block_env: &dyn BlockEnvironment = &block_env;
+
+        assert_eq!(dyn_block_env.number(), block_env.number());
     }
 
     #[test]

--- a/crates/evm/src/env.rs
+++ b/crates/evm/src/env.rs
@@ -298,6 +298,15 @@ mod tests {
     }
 
     #[test]
+    fn test_dyn_block_environment_downcasts_to_block_env() {
+        let block_env = BlockEnv::default();
+        let dyn_block_env: &dyn BlockEnvironment = &block_env;
+        let any_block_env = dyn_block_env as &dyn Any;
+
+        assert!(any_block_env.downcast_ref::<BlockEnv>().is_some());
+    }
+
+    #[test]
     fn test_evm_env_with_osaka_limits() {
         // osaka() has tx_gas_limit_cap set to EIP-7825's cap.
         use revm::context::{BlockEnv, CfgEnv};

--- a/crates/evm/src/precompiles.rs
+++ b/crates/evm/src/precompiles.rs
@@ -1,6 +1,6 @@
 //! Helpers for dealing with Precompiles.
 
-use crate::{Database, EvmInternals};
+use crate::{env::BlockEnvironment, Database, EvmInternals};
 use alloc::{
     borrow::Cow,
     boxed::Box,
@@ -550,7 +550,7 @@ impl core::fmt::Debug for PrecompilesMap {
 impl<BlockEnv, TxEnv, CfgEnv, DB, Chain>
     PrecompileProvider<Context<BlockEnv, TxEnv, CfgEnv, DB, Journal<DB>, Chain>> for PrecompilesMap
 where
-    BlockEnv: revm::context::Block,
+    BlockEnv: BlockEnvironment,
     TxEnv: revm::context::Transaction,
     CfgEnv: revm::context::Cfg,
     DB: Database,
@@ -987,7 +987,6 @@ mod tests {
     use crate::eth::EthEvmContext;
     use alloy_primitives::{address, Bytes};
     use revm::{
-        context::Block,
         database::EmptyDB,
         precompile::{PrecompileId, PrecompileOutput},
         primitives::hardfork::SpecId,

--- a/crates/evm/src/precompiles.rs
+++ b/crates/evm/src/precompiles.rs
@@ -987,6 +987,7 @@ mod tests {
     use crate::eth::EthEvmContext;
     use alloy_primitives::{address, Bytes};
     use revm::{
+        context::BlockEnv,
         database::EmptyDB,
         precompile::{PrecompileId, PrecompileOutput},
         primitives::hardfork::SpecId,
@@ -1068,6 +1069,14 @@ mod tests {
             result.bytes, constant_bytes,
             "Modified precompile should return the constant value"
         );
+    }
+
+    #[test]
+    fn test_evm_internals_downcasts_block_env() {
+        let mut ctx = EthEvmContext::new(EmptyDB::default(), Default::default());
+        let internals = EvmInternals::from_context(&mut ctx);
+
+        assert!(internals.block_env_downcast_ref::<BlockEnv>().is_some());
     }
 
     #[test]

--- a/crates/evm/src/traits.rs
+++ b/crates/evm/src/traits.rs
@@ -1,6 +1,6 @@
 //! EVM traits.
 
-use crate::Database;
+use crate::{env::BlockEnvironment, Database};
 use alloc::boxed::Box;
 use alloy_primitives::{Address, Bytes, Log, TxKind, B256, U256};
 use core::{error::Error, fmt, fmt::Debug};
@@ -10,7 +10,7 @@ use revm::{
             account::JournaledAccountTr, JournalCheckpoint, JournalLoadError, TransferError,
         },
         result::InvalidTransaction,
-        Block, Cfg, ContextTr, DBErrorMarker, JournalTr,
+        Cfg, ContextTr, DBErrorMarker, JournalTr,
     },
     interpreter::{SStoreResult, StateLoad},
     primitives::{StorageKey, StorageValue},
@@ -469,7 +469,7 @@ where
 /// Helper type exposing hooks into EVM and access to evm internal settings.
 pub struct EvmInternals<'a> {
     internals: Box<dyn EvmInternalsTr + 'a>,
-    block_env: &'a (dyn Block + 'a),
+    block_env: &'a dyn BlockEnvironment,
     chain_id: u64,
     tx_origin: Address,
     tx_env: &'a dyn TransactionTr,
@@ -479,7 +479,7 @@ impl<'a> EvmInternals<'a> {
     /// Creates a new [`EvmInternals`] instance.
     pub fn new<T>(
         journal: &'a mut T,
-        block_env: &'a dyn Block,
+        block_env: &'a dyn BlockEnvironment,
         cfg_env: &'a impl Cfg,
         tx_env: &'a dyn TransactionTr,
     ) -> Self
@@ -498,14 +498,14 @@ impl<'a> EvmInternals<'a> {
     /// Creates a new [`EvmInternals`] instance from a [`ContextTr`].
     pub fn from_context<CTX>(ctx: &'a mut CTX) -> Self
     where
-        CTX: ContextTr<Journal: JournalTr<Database: Database> + Debug>,
+        CTX: ContextTr<Block: BlockEnvironment, Journal: JournalTr<Database: Database> + Debug>,
     {
         let (block, tx, cfg, journaled_state, ..) = ctx.all_mut();
         Self::new(journaled_state, block, cfg, tx)
     }
 
     /// Returns the  evm's block information.
-    pub const fn block_env(&self) -> impl Block + 'a {
+    pub const fn block_env(&self) -> &dyn BlockEnvironment {
         self.block_env
     }
 

--- a/crates/evm/src/traits.rs
+++ b/crates/evm/src/traits.rs
@@ -509,6 +509,11 @@ impl<'a> EvmInternals<'a> {
         self.block_env
     }
 
+    /// Attempts to downcast the block environment to a concrete type.
+    pub fn block_env_downcast_ref<T: BlockEnvironment>(&self) -> Option<&T> {
+        (self.block_env as &dyn core::any::Any).downcast_ref()
+    }
+
     /// Returns the current block number.
     pub fn block_number(&self) -> U256 {
         self.block_env.number()


### PR DESCRIPTION
## Summary
- make `BlockEnvironment` object-safe and add `Any` as a supertrait
- expose `EvmInternals::block_env` as `&dyn BlockEnvironment`
- require `BlockEnvironment` where precompiles construct `EvmInternals`

Prompted by: @klkvr

## Testing
- `cargo fmt --all --check`
- `cargo check -p alloy-evm`
- `cargo test -p alloy-evm test_block_environment_is_dyn_compatible`

Note: `cargo check -p alloy-evm --all-features` is blocked in this sandbox because `gmp-mpfr-sys` cannot find `m4`.