### PR TITLE
feat(eth): add EIP-7997 deterministic factory

### DIFF
--- a/crates/evm/src/eth/block.rs
+++ b/crates/evm/src/eth/block.rs
@@ -3,7 +3,7 @@
 use core::cmp::min;
 
 use super::{
-    dao_fork, eip6110,
+    dao_fork, eip6110, eip7997,
     receipt_builder::{AlloyReceiptBuilder, ReceiptBuilder, ReceiptBuilderCtx},
     spec::{EthExecutorSpec, EthSpec},
     EthEvmFactory,
@@ -158,6 +158,11 @@ where
         self.system_caller.apply_blockhashes_contract_call(self.ctx.parent_hash, &mut self.evm)?;
         self.system_caller
             .apply_beacon_root_contract_call(self.ctx.parent_beacon_block_root, &mut self.evm)?;
+
+        let timestamp = self.evm.block().timestamp().saturating_to();
+        if self.spec.is_amsterdam_active_at_timestamp(timestamp) {
+            eip7997::insert_deterministic_factory_account(self.evm.db_mut())?;
+        }
 
         Ok(())
     }
@@ -400,5 +405,85 @@ where
         I: Inspector<EvmF::Context<DB>>,
     {
         EthBlockExecutor::new(evm, ctx, &self.spec, &self.receipt_builder)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{eth::eip7997, EvmEnv};
+    use alloy_hardforks::{EthereumHardfork, EthereumHardforks, ForkCondition};
+    use alloy_primitives::{Address, U256};
+    use revm::{
+        context::{BlockEnv, CfgEnv},
+        database::{CacheDB, State},
+        database_interface::EmptyDB,
+        primitives::hardfork::SpecId,
+        Database as _,
+    };
+
+    #[derive(Clone, Copy, Debug)]
+    struct TestSpec {
+        amsterdam: ForkCondition,
+    }
+
+    impl TestSpec {
+        const fn amsterdam_at(timestamp: u64) -> Self {
+            Self { amsterdam: ForkCondition::Timestamp(timestamp) }
+        }
+    }
+
+    impl EthereumHardforks for TestSpec {
+        fn ethereum_fork_activation(&self, fork: EthereumHardfork) -> ForkCondition {
+            match fork {
+                EthereumHardfork::Amsterdam => self.amsterdam,
+                _ => ForkCondition::Never,
+            }
+        }
+    }
+
+    impl EthExecutorSpec for TestSpec {
+        fn deposit_contract_address(&self) -> Option<Address> {
+            None
+        }
+    }
+
+    fn apply_pre_execution_changes(timestamp: u64, spec: TestSpec) -> State<CacheDB<EmptyDB>> {
+        let db = State::builder().with_database(CacheDB::new(EmptyDB::new())).build();
+        let mut cfg_env = CfgEnv::default();
+        cfg_env.spec = SpecId::AMSTERDAM;
+        cfg_env.chain_id = 1;
+        let block_env = BlockEnv { timestamp: U256::from(timestamp), ..Default::default() };
+
+        let evm = EthEvmFactory.create_evm(db, EvmEnv { block_env, cfg_env });
+        let ctx = EthBlockExecutionCtx {
+            parent_hash: B256::ZERO,
+            parent_beacon_block_root: None,
+            ommers: &[],
+            withdrawals: None,
+            extra_data: Bytes::new(),
+            tx_count_hint: None,
+            slot_number: None,
+        };
+        let mut executor = EthBlockExecutor::new(evm, ctx, spec, AlloyReceiptBuilder::default());
+
+        executor.apply_pre_execution_changes().unwrap();
+        executor.evm.into_db()
+    }
+
+    #[test]
+    fn inserts_deterministic_factory_when_amsterdam_is_active() {
+        let mut db = apply_pre_execution_changes(10, TestSpec::amsterdam_at(10));
+
+        let info = db.basic(eip7997::DETERMINISTIC_FACTORY_ADDRESS).unwrap().unwrap();
+        assert_eq!(info.nonce, 1);
+        assert_eq!(info.code_hash, eip7997::deterministic_factory_runtime_bytecode().hash_slow());
+    }
+
+    #[test]
+    fn skips_deterministic_factory_before_amsterdam() {
+        let mut db = apply_pre_execution_changes(9, TestSpec::amsterdam_at(10));
+
+        assert!(db.basic(eip7997::DETERMINISTIC_FACTORY_ADDRESS).unwrap().is_none());
     }
 }

--- a/crates/evm/src/eth/eip7997.rs
+++ b/crates/evm/src/eth/eip7997.rs
@@ -43,6 +43,7 @@ where
 
     let mut account = Account::from(info);
     if account.info.nonce == 0 {
+        // Mirror normal contract creation semantics: deployed contracts start with nonce 1.
         account.info.nonce = 1;
     }
     account.info.code_hash = code_hash;

--- a/crates/evm/src/eth/eip7997.rs
+++ b/crates/evm/src/eth/eip7997.rs
@@ -1,0 +1,93 @@
+//! [EIP-7997](https://eips.ethereum.org/EIPS/eip-7997) deterministic factory support.
+
+use crate::{block::BlockExecutionError, Database};
+use alloy_primitives::{address, bytes, Address, Bytes};
+use revm::{
+    state::{Account, Bytecode, EvmState},
+    DatabaseCommit,
+};
+
+/// Address of the EIP-7997 deterministic factory.
+pub const DETERMINISTIC_FACTORY_ADDRESS: Address =
+    address!("0x4e59b44847b379578588920cA78FbF26c0B4956C");
+
+/// Returns the EIP-7997 deterministic factory runtime code.
+pub const fn deterministic_factory_runtime_code() -> Bytes {
+    bytes!(
+        "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe03601600081602082378035828234f58015156039578182fd5b8082525050506014600cf3"
+    )
+}
+
+/// Returns the EIP-7997 deterministic factory runtime bytecode.
+pub fn deterministic_factory_runtime_bytecode() -> Bytecode {
+    Bytecode::new_legacy(deterministic_factory_runtime_code())
+}
+
+/// Inserts the EIP-7997 deterministic factory account if the current state does not already match.
+///
+/// If the account nonce is zero, it is set to one. Any existing nonzero nonce is preserved.
+pub fn insert_deterministic_factory_account<DB>(db: &mut DB) -> Result<(), BlockExecutionError>
+where
+    DB: Database + DatabaseCommit,
+{
+    let code = deterministic_factory_runtime_bytecode();
+    let code_hash = code.hash_slow();
+    let info = db
+        .basic(DETERMINISTIC_FACTORY_ADDRESS)
+        .map_err(BlockExecutionError::other)?
+        .unwrap_or_default();
+
+    if info.nonce != 0 && info.code_hash == code_hash {
+        return Ok(());
+    }
+
+    let mut account = Account::from(info);
+    if account.info.nonce == 0 {
+        account.info.nonce = 1;
+    }
+    account.info.code_hash = code_hash;
+    account.info.code = Some(code);
+    account.mark_touch();
+
+    db.commit(EvmState::from_iter([(DETERMINISTIC_FACTORY_ADDRESS, account)]));
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use revm::{
+        database::{CacheDB, State},
+        database_interface::EmptyDB,
+        state::AccountInfo,
+        Database as _, DatabaseCommit,
+    };
+
+    #[test]
+    fn inserts_factory_account() {
+        let mut db = State::builder().with_database(CacheDB::new(EmptyDB::new())).build();
+
+        insert_deterministic_factory_account(&mut db).unwrap();
+
+        let info = db.basic(DETERMINISTIC_FACTORY_ADDRESS).unwrap().unwrap();
+        let code = info.code.unwrap();
+        assert_eq!(info.nonce, 1);
+        assert_eq!(info.code_hash, deterministic_factory_runtime_bytecode().hash_slow());
+        assert_eq!(code.original_bytes(), deterministic_factory_runtime_code());
+    }
+
+    #[test]
+    fn preserves_existing_nonzero_nonce() {
+        let mut db = State::builder().with_database(CacheDB::new(EmptyDB::new())).build();
+        let mut account = Account::from(AccountInfo { nonce: 7, ..Default::default() });
+        account.mark_touch();
+        db.commit(EvmState::from_iter([(DETERMINISTIC_FACTORY_ADDRESS, account)]));
+
+        insert_deterministic_factory_account(&mut db).unwrap();
+
+        let info = db.basic(DETERMINISTIC_FACTORY_ADDRESS).unwrap().unwrap();
+        assert_eq!(info.nonce, 7);
+        assert_eq!(info.code_hash, deterministic_factory_runtime_bytecode().hash_slow());
+    }
+}

--- a/crates/evm/src/eth/mod.rs
+++ b/crates/evm/src/eth/mod.rs
@@ -24,6 +24,7 @@ pub use block::*;
 
 pub mod dao_fork;
 pub mod eip6110;
+pub mod eip7997;
 pub mod receipt_builder;
 pub mod spec;
 


### PR DESCRIPTION
Adds support for the EIP-7997 deterministic factory during Ethereum block pre-execution once Amsterdam is active. The state transition installs the specified runtime code at the factory address and sets a zero nonce to one while preserving any existing nonzero nonce.

EIP: https://eips.ethereum.org/EIPS/eip-7997


TODO: check for side-effects if this contract is already deployed 
