### PR TITLE
feat: parameterize executor creation over the database type

### DIFF
--- a/crates/evm/src/block/mod.rs
+++ b/crates/evm/src/block/mod.rs
@@ -1,7 +1,7 @@
 //! Block execution abstraction.
 
 use crate::{Evm, EvmFactory, FromRecoveredTx, FromTxWithEncoded, RecoveredTx, ToTxEnv};
-use alloc::vec::Vec;
+use alloc::{sync::Arc, vec::Vec};
 use alloy_consensus::transaction::Recovered;
 use alloy_eips::{eip2718::WithEncoded, eip7685::Requests};
 use revm::{
@@ -475,17 +475,22 @@ pub trait TxResult: Send + 'static {
     fn into_result(self) -> ResultAndState<Self::HaltReason>;
 }
 
-/// A helper trait encapsulating the constraints on [`BlockExecutor`] produced by the
-/// [`BlockExecutorFactory`] to avoid duplicating them in every implementation.
+/// A helper alias for the [`BlockExecutor`] produced by a [`BlockExecutorFactoryFor`] to avoid
+/// duplicating the projection in every implementation.
 pub type BlockExecutorFor<'a, F, DB, I = NoOpInspector> =
-    <F as BlockExecutorFactory>::Executor<'a, DB, I>;
+    <F as BlockExecutorFactoryFor<DB>>::Executor<'a, I>;
 
 /// A factory that can create [`BlockExecutor`]s.
 ///
-/// This trait serves as the main entry point for block execution, providing a way to construct
-/// [`BlockExecutor`] instances with the necessary context. It separates the concerns of:
+/// This trait declares the types shared by every executor the factory produces: the
+/// [`EvmFactory`], the consensus transaction and receipt types, the per-transaction execution
+/// result and the block execution context. Executor construction lives on
+/// [`BlockExecutorFactoryFor`], implemented per supported database type.
+///
+/// It separates the concerns of:
 /// - EVM configuration (handled by [`EvmFactory`])
 /// - Block-specific execution context (provided via [`ExecutionCtx`])
+/// - Database requirements (declared by [`BlockExecutorFactoryFor`] implementations)
 ///
 /// It allows for:
 /// - Reusable EVM configuration across multiple block executions
@@ -565,16 +570,32 @@ pub trait BlockExecutorFactory: 'static {
     /// Receipt type produced by the executor, see [`BlockExecutor::Receipt`].
     type Receipt;
 
-    /// The executor type this factory produces.
-    type Executor<'a, DB: StateDB, I: Inspector<<Self::EvmFactory as EvmFactory>::Context<DB>>>: BlockExecutor<
+    /// Reference to EVM factory used by the executor.
+    fn evm_factory(&self) -> &Self::EvmFactory;
+}
+
+/// A [`BlockExecutorFactory`] that can create [`BlockExecutor`]s operating on the database `DB`.
+///
+/// This trait serves as the main entry point for block execution, providing a way to construct
+/// [`BlockExecutor`] instances with the necessary context. It is parameterized by the database
+/// type so that every factory declares which databases its executors support.
+///
+/// # Implementations
+///
+/// - Factories whose executors rely only on the [`StateDB`] contract should implement this trait
+///   for all `DB: StateDB`, supporting any database (e.g.
+///   [`EthBlockExecutorFactory`](crate::eth::EthBlockExecutorFactory)).
+/// - Factories whose executors require database capabilities beyond [`StateDB`] — e.g. the
+///   [`State`](revm::database::State) transition layer or [`BalIndexedDatabase`] index tracking —
+///   should implement it only for databases providing them, such as `&mut State<D>`.
+pub trait BlockExecutorFactoryFor<DB: StateDB>: BlockExecutorFactory {
+    /// The executor type this factory produces for `DB`.
+    type Executor<'a, I: Inspector<<Self::EvmFactory as EvmFactory>::Context<DB>>>: BlockExecutor<
         Evm = <Self::EvmFactory as EvmFactory>::Evm<DB, I>,
         Transaction = Self::Transaction,
         Receipt = Self::Receipt,
         Result = Self::TxExecutionResult,
     >;
-
-    /// Reference to EVM factory used by the executor.
-    fn evm_factory(&self) -> &Self::EvmFactory;
 
     /// Creates an executor with given EVM and execution context.
     ///
@@ -615,12 +636,32 @@ pub trait BlockExecutorFactory: 'static {
     /// // 3. Apply post-execution changes (e.g., process withdrawals, apply rewards)
     /// let result = executor.execute_block(transactions)?;
     /// ```
-    fn create_executor<'a, DB, I>(
+    fn create_executor<'a, I>(
         &'a self,
         evm: <Self::EvmFactory as EvmFactory>::Evm<DB, I>,
         ctx: Self::ExecutionCtx<'a>,
-    ) -> Self::Executor<'a, DB, I>
+    ) -> Self::Executor<'a, I>
     where
-        DB: StateDB,
         I: Inspector<<Self::EvmFactory as EvmFactory>::Context<DB>>;
+}
+
+/// `auto_impl` is unable to reconcile associated types projected from the supertrait.
+impl<T, DB> BlockExecutorFactoryFor<DB> for Arc<T>
+where
+    T: BlockExecutorFactoryFor<DB>,
+    DB: StateDB,
+{
+    type Executor<'a, I: Inspector<<Self::EvmFactory as EvmFactory>::Context<DB>>> =
+        T::Executor<'a, I>;
+
+    fn create_executor<'a, I>(
+        &'a self,
+        evm: <Self::EvmFactory as EvmFactory>::Evm<DB, I>,
+        ctx: Self::ExecutionCtx<'a>,
+    ) -> Self::Executor<'a, I>
+    where
+        I: Inspector<<Self::EvmFactory as EvmFactory>::Context<DB>>,
+    {
+        (**self).create_executor(evm, ctx)
+    }
 }

--- a/crates/evm/src/eth/block.rs
+++ b/crates/evm/src/eth/block.rs
@@ -11,8 +11,8 @@ use super::{
 use crate::{
     block::{
         state_changes::post_block_balance_increments, BlockExecutionError, BlockExecutionResult,
-        BlockExecutor, BlockExecutorFactory, BlockValidationError, ExecutableTx, GasOutput,
-        StateDB, SystemCaller, TxResult,
+        BlockExecutor, BlockExecutorFactory, BlockExecutorFactoryFor, BlockValidationError,
+        ExecutableTx, GasOutput, StateDB, SystemCaller, TxResult,
     },
     Evm, EvmFactory, FromRecoveredTx, FromTxWithEncoded, RecoveredTx,
 };
@@ -383,22 +383,76 @@ where
         <EvmF as EvmFactory>::HaltReason,
         <R::Transaction as TransactionEnvelope>::TxType,
     >;
-    type Executor<'a, DB: StateDB, I: Inspector<EvmF::Context<DB>>> =
-        EthBlockExecutor<'a, EvmF::Evm<DB, I>, &'a Spec, &'a R>;
 
     fn evm_factory(&self) -> &Self::EvmFactory {
         &self.evm_factory
     }
+}
 
-    fn create_executor<'a, DB, I>(
+impl<DB, R, Spec, EvmF> BlockExecutorFactoryFor<DB> for EthBlockExecutorFactory<R, Spec, EvmF>
+where
+    DB: StateDB,
+    R: ReceiptBuilder<Transaction: Transaction + Encodable2718, Receipt: TxReceipt<Log = Log>>,
+    Spec: EthExecutorSpec,
+    EvmF: EvmFactory<Tx: FromRecoveredTx<R::Transaction> + FromTxWithEncoded<R::Transaction>>,
+    <R::Transaction as TransactionEnvelope>::TxType: Send + 'static,
+    Self: 'static,
+{
+    type Executor<'a, I: Inspector<EvmF::Context<DB>>> =
+        EthBlockExecutor<'a, EvmF::Evm<DB, I>, &'a Spec, &'a R>;
+
+    fn create_executor<'a, I>(
         &'a self,
         evm: EvmF::Evm<DB, I>,
         ctx: Self::ExecutionCtx<'a>,
-    ) -> Self::Executor<'a, DB, I>
+    ) -> Self::Executor<'a, I>
     where
-        DB: StateDB,
         I: Inspector<EvmF::Context<DB>>,
     {
         EthBlockExecutor::new(evm, ctx, &self.spec, &self.receipt_builder)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::EvmEnv;
+    use alloy_consensus::{transaction::Recovered, TxEnvelope};
+    use revm::{
+        database::{CacheDB, State},
+        database_interface::EmptyDB,
+    };
+
+    fn assert_factory_for<DB, F>()
+    where
+        DB: StateDB,
+        F: BlockExecutorFactoryFor<DB>,
+    {
+    }
+
+    #[test]
+    fn eth_factory_supports_any_state_db() {
+        assert_factory_for::<CacheDB<EmptyDB>, EthBlockExecutorFactory>();
+        assert_factory_for::<&mut State<CacheDB<EmptyDB>>, EthBlockExecutorFactory>();
+    }
+
+    #[test]
+    fn executes_empty_block_over_state() {
+        let factory =
+            EthBlockExecutorFactory::new(AlloyReceiptBuilder, EthSpec::mainnet(), EthEvmFactory);
+        let mut state = State::builder().with_database(CacheDB::new(EmptyDB::new())).build();
+        let evm = factory.evm_factory().create_evm(&mut state, EvmEnv::default());
+        let ctx = EthBlockExecutionCtx {
+            parent_hash: B256::ZERO,
+            parent_beacon_block_root: None,
+            ommers: &[],
+            withdrawals: None,
+            extra_data: Bytes::new(),
+            tx_count_hint: None,
+            slot_number: None,
+        };
+        let executor = factory.create_executor(evm, ctx);
+        let result = executor.execute_block(Vec::<Recovered<TxEnvelope>>::new()).unwrap();
+        assert_eq!(result, BlockExecutionResult::default());
     }
 }


### PR DESCRIPTION
## Motivation

`BlockExecutorFactory::Executor` and `create_executor` are generic over every
`DB: StateDB`, so a factory must be able to build executors for any database.
An executor that needs database capabilities beyond `Database + DatabaseCommit`
cannot be written against this trait: the implementation is not allowed to
narrow `DB`, and `StateDB` cannot expose `State`-specific functionality without
giving up its blanket impl. #233 and #238 hit versions of this from the wrapper
side, and the BAL methods on `BlockExecutor` work around it with per-method
bounds (`where <Self::Evm as Evm>::DB: BalIndexedDatabase`) because a factory
has no way to state such a requirement itself.

We ran into this while building Arbitrum Reth. ArbOS applies state changes
between transactions and needs direct access to the underlying `State`, which
cannot be reached through `Database + DatabaseCommit`.

## Solution

Split executor construction out of `BlockExecutorFactory` into a
database-parameterized trait:

- `BlockExecutorFactory` keeps the chain-level associated types (`EvmFactory`,
  `ExecutionCtx`, `Transaction`, `Receipt`, `TxExecutionResult`).
- The new `BlockExecutorFactoryFor<DB: StateDB>` carries the `Executor` GAT and
  `create_executor`. Factories implement it for the databases their executors
  support.

`EthBlockExecutorFactory` implements it for all `DB: StateDB`, so its behavior
and flexibility are unchanged, `StateDB` stays a pure alias with its blanket
impl, and executors keep working over plain `CacheDB`. A factory with stronger
requirements implements the trait for specific databases only, for example
`&'db mut State<D>`, which gives its executors typed access to `State` without
any changes to `StateDB`. A factory that requires BAL tracking could implement
it for `DB: StateDB + BalIndexedDatabase` and rely on the indexed execution
methods unconditionally.

`BlockExecutorFor` keeps its exact signature and now projects through the new
trait, so code using the alias does not change. The `Arc` impl is written by
hand because `auto_impl` cannot reconcile associated types projected from the
supertrait, which is the same limitation that came up in #234.

This is a breaking change for `BlockExecutorFactory` implementors. Migration is
mechanical: move the `DB` parameter from the `Executor` GAT and
`create_executor` into the impl header, as done for `EthBlockExecutorFactory`
here.

For reth, current main references `BlockExecutorFactory` in 7 files.
`aliases.rs`, the ethereum node config and the noop config compile unchanged.
`ConfigureEvm`'s executor-creating helper methods and `BasicBlockExecutor` need
where clauses, and call sites that create executors over a generic database
need a one-line bound, on the order of 100-200 lines total. Happy to open the
companion reth PR if this direction is acceptable.

Opening as a draft to get feedback on the direction first.

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [x] Breaking changes
