### PR TITLE
feat(evm): support transaction environment downcasting

### DIFF
--- a/crates/evm/src/precompiles.rs
+++ b/crates/evm/src/precompiles.rs
@@ -551,7 +551,7 @@ impl<BlockEnv, TxEnv, CfgEnv, DB, Chain>
     PrecompileProvider<Context<BlockEnv, TxEnv, CfgEnv, DB, Journal<DB>, Chain>> for PrecompilesMap
 where
     BlockEnv: BlockEnvironment,
-    TxEnv: revm::context::Transaction,
+    TxEnv: revm::context::Transaction + 'static,
     CfgEnv: revm::context::Cfg,
     DB: Database,
 {
@@ -987,7 +987,7 @@ mod tests {
     use crate::eth::EthEvmContext;
     use alloy_primitives::{address, Bytes};
     use revm::{
-        context::BlockEnv,
+        context::{BlockEnv, TxEnv},
         database::EmptyDB,
         precompile::{PrecompileId, PrecompileOutput},
         primitives::hardfork::SpecId,
@@ -1072,11 +1072,12 @@ mod tests {
     }
 
     #[test]
-    fn test_evm_internals_downcasts_block_env() {
+    fn test_evm_internals_downcasts_envs() {
         let mut ctx = EthEvmContext::new(EmptyDB::default(), Default::default());
         let internals = EvmInternals::from_context(&mut ctx);
 
         assert!(internals.block_env_downcast_ref::<BlockEnv>().is_some());
+        assert!(internals.tx_env_downcast_ref::<TxEnv>().is_some());
     }
 
     #[test]

--- a/crates/evm/src/traits.rs
+++ b/crates/evm/src/traits.rs
@@ -3,7 +3,7 @@
 use crate::{env::BlockEnvironment, Database};
 use alloc::boxed::Box;
 use alloy_primitives::{Address, Bytes, Log, TxKind, B256, U256};
-use core::{error::Error, fmt, fmt::Debug};
+use core::{any::Any, error::Error, fmt, fmt::Debug};
 use revm::{
     context::{
         journaled_state::{
@@ -52,7 +52,7 @@ impl EvmInternalsError {
 /// associated types (e.g. `access_list`, `authorization_list`). This trait mirrors
 /// the dyn-compatible subset of those methods, allowing transaction data to be
 /// accessed through `&dyn TransactionTr` in [`EvmInternals`].
-pub trait TransactionTr {
+pub trait TransactionTr: Any {
     /// Returns the transaction type.
     ///
     /// Depending on this field other functions should be called.
@@ -165,7 +165,7 @@ pub trait TransactionTr {
 
 impl<T> TransactionTr for T
 where
-    T: revm::context::Transaction,
+    T: revm::context::Transaction + 'static,
 {
     fn tx_type(&self) -> u8 {
         revm::context::Transaction::tx_type(self)
@@ -499,6 +499,7 @@ impl<'a> EvmInternals<'a> {
     pub fn from_context<CTX>(ctx: &'a mut CTX) -> Self
     where
         CTX: ContextTr<Block: BlockEnvironment, Journal: JournalTr<Database: Database> + Debug>,
+        CTX::Tx: 'static,
     {
         let (block, tx, cfg, journaled_state, ..) = ctx.all_mut();
         Self::new(journaled_state, block, cfg, tx)
@@ -539,6 +540,11 @@ impl<'a> EvmInternals<'a> {
     /// Returns the current transaction information.
     pub fn tx_env(&self) -> &dyn TransactionTr {
         self.tx_env
+    }
+
+    /// Attempts to downcast the transaction environment to a concrete type.
+    pub fn tx_env_downcast_ref<T: TransactionTr>(&self) -> Option<&T> {
+        (self.tx_env as &dyn Any).downcast_ref()
     }
 
     /// Returns a mutable reference to [`Database`] implementation with erased error type.


### PR DESCRIPTION
## Motivation

`EvmInternals` exposes concrete block environments through `block_env_downcast_ref`, but transaction environments can only be accessed through `dyn TransactionTr`. Custom transaction fields therefore cannot be recovered by precompiles.

## Solution

Make `TransactionTr` type-erased through `Any` and add `EvmInternals::tx_env_downcast_ref`, mirroring the block environment API. Extend the existing environment downcast test to cover revm `TxEnv`.

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [ ] Breaking changes

## Validation

- `cargo test -p alloy-evm test_evm_internals_downcasts_envs`
- `cargo +nightly fmt --all -- --check`
- `cargo +nightly clippy -p alloy-evm --lib -- -D warnings`

All-features Clippy was attempted but the sandbox lacks `m4`, required to build `gmp-mpfr-sys`.

Prompted by: @klkvr