### PR TITLE
feat(system-calls): reject blocks when EIP-8282 builder contracts have no code

### DIFF
--- a/crates/evm/src/block/error.rs
+++ b/crates/evm/src/block/error.rs
@@ -100,6 +100,14 @@ pub enum BlockValidationError {
         /// The error message.
         message: String,
     },
+    /// A required system contract has no code deployed [EIP-8282]
+    ///
+    /// [EIP-8282]: https://eips.ethereum.org/EIPS/eip-8282
+    #[error("system contract {address} has no code")]
+    SystemContractEmpty {
+        /// The system contract address.
+        address: alloy_primitives::Address,
+    },
     /// Error when decoding deposit requests from receipts [EIP-6110]
     ///
     /// [EIP-6110]: https://eips.ethereum.org/EIPS/eip-6110

--- a/crates/evm/src/block/system_calls/eip8282.rs
+++ b/crates/evm/src/block/system_calls/eip8282.rs
@@ -20,7 +20,10 @@ use alloc::format;
 use alloy_eips::eip7002::SYSTEM_ADDRESS;
 use alloy_primitives::{address, Address, Bytes};
 use core::fmt::Debug;
-use revm::context_interface::result::{ExecutionResult, ResultAndState};
+use revm::{
+    context_interface::result::{ExecutionResult, ResultAndState},
+    Database as _,
+};
 
 /// The [EIP-7685](https://eips.ethereum.org/EIPS/eip-7685) request type for EIP-8282 builder
 /// deposit requests.
@@ -45,6 +48,9 @@ pub const BUILDER_EXIT_REQUEST_PREDEPLOY_ADDRESS: Address =
 pub(crate) fn transact_builder_deposit_requests_contract_call<Halt>(
     evm: &mut impl Evm<HaltReason = Halt>,
 ) -> Result<ResultAndState<Halt>, BlockExecutionError> {
+    // A block executed while the predeploy has no code is invalid.
+    ensure_contract_deployed(evm, BUILDER_DEPOSIT_REQUEST_PREDEPLOY_ADDRESS)?;
+
     // At the end of processing any execution block where Amsterdam is active, call the builder
     // deposit requests contract as `SYSTEM_ADDRESS` with empty calldata.
     match evm.transact_system_call(
@@ -60,6 +66,25 @@ pub(crate) fn transact_builder_deposit_requests_contract_call<Halt>(
     }
 }
 
+/// Returns an error if the system contract at `address` has no code.
+fn ensure_contract_deployed<Halt>(
+    evm: &mut impl Evm<HaltReason = Halt>,
+    address: Address,
+) -> Result<(), BlockExecutionError> {
+    let deployed = evm
+        .db_mut()
+        .basic(address)
+        .map_err(|e| BlockValidationError::BuilderDepositRequestsContractCall {
+            message: format!("database error: {e}"),
+        })?
+        .is_some_and(|account| !account.is_empty_code_hash());
+
+    if !deployed {
+        return Err(BlockValidationError::SystemContractEmpty { address }.into());
+    }
+    Ok(())
+}
+
 /// Applies the post-block call to the EIP-8282 builder exit requests contract.
 ///
 /// Note: this does not commit the state changes to the database, it only transacts the call.
@@ -67,6 +92,9 @@ pub(crate) fn transact_builder_deposit_requests_contract_call<Halt>(
 pub(crate) fn transact_builder_exit_requests_contract_call<Halt>(
     evm: &mut impl Evm<HaltReason = Halt>,
 ) -> Result<ResultAndState<Halt>, BlockExecutionError> {
+    // A block executed while the predeploy has no code is invalid.
+    ensure_contract_deployed(evm, BUILDER_EXIT_REQUEST_PREDEPLOY_ADDRESS)?;
+
     match evm.transact_system_call(
         SYSTEM_ADDRESS,
         BUILDER_EXIT_REQUEST_PREDEPLOY_ADDRESS,


### PR DESCRIPTION
A block executed while an EIP-8282 builder predeploy has no code must be invalid, mirroring the EIP-7002/7251 semantics. The system call to an empty contract currently no-ops (empty output, no requests), so such blocks fail much later with misleading errors — on hive glamsterdam-quick (fixtures `tests-glamsterdam-devnet@v8.1.0`), reth rejects the four `test_builder_{deposit,exit}_contract_deployment[deploy_after_fork…]` cases with a BAL hash mismatch where the tests expect `SYSTEM_CONTRACT_EMPTY`; besu/nethermind/erigon/ethrex implement the empty-code check and pass.

Fix: check the predeploy's code before the system call in `transact_builder_{deposit,exit}_requests_contract_call` and return a new `BlockValidationError::SystemContractEmpty { address }` ("system contract {address} has no code") when it is missing. The message shape is deliberately distinct from the `failed to apply … requests contract call` family so downstream consumers (e.g. the EELS exception mapper) can distinguish empty-contract from call-failure rejections.

Verified: `alloy-evm` tests pass; reth (glamsterdam-devnet-8) compiles and its `payload_processor::bal` suite passes against this branch. Companion reth pin: paradigmxyz/reth PR (linked below).
