### PR TITLE
fix: reject blocks when request predeploys have no code

### DIFF
--- a/crates/evm/src/block/system_calls/eip7002.rs
+++ b/crates/evm/src/block/system_calls/eip7002.rs
@@ -24,6 +24,13 @@ pub(crate) fn transact_withdrawal_requests_contract_call<Halt>(
     // The requirement for the withdrawal requests contract call defined by
     // [EIP-7002](https://eips.ethereum.org/EIPS/eip-7002) is:
     //
+    // The predeploy must exist: if there is no code at the address, the block is invalid.
+    super::eip8282::ensure_contract_has_code(
+        evm,
+        WITHDRAWAL_REQUEST_PREDEPLOY_ADDRESS,
+        |message| BlockValidationError::WithdrawalRequestsContractCall { message }.into(),
+    )?;
+
     // At the end of processing any execution block where `block.timestamp >= FORK_TIMESTAMP` (i.e.
     // after processing all transactions and after performing the block body withdrawal requests
     // validations), call the contract as `SYSTEM_ADDRESS`.

--- a/crates/evm/src/block/system_calls/eip7251.rs
+++ b/crates/evm/src/block/system_calls/eip7251.rs
@@ -20,6 +20,13 @@ use revm::context_interface::result::{ExecutionResult, ResultAndState};
 pub(crate) fn transact_consolidation_requests_contract_call<Halt>(
     evm: &mut impl Evm<HaltReason = Halt>,
 ) -> Result<ResultAndState<Halt>, BlockExecutionError> {
+    // The predeploy must exist: if there is no code at the address, the block is invalid.
+    super::eip8282::ensure_contract_has_code(
+        evm,
+        CONSOLIDATION_REQUEST_PREDEPLOY_ADDRESS,
+        |message| BlockValidationError::ConsolidationRequestsContractCall { message }.into(),
+    )?;
+
     // Execute EIP-7251 consolidation requests contract call.
     //
     // The requirement for the consolidation requests contract call defined by

--- a/crates/evm/src/block/system_calls/eip8282.rs
+++ b/crates/evm/src/block/system_calls/eip8282.rs
@@ -16,11 +16,14 @@ use crate::{
     block::{BlockExecutionError, BlockValidationError},
     Evm,
 };
-use alloc::format;
+use alloc::{format, string::ToString};
 use alloy_eips::eip7002::SYSTEM_ADDRESS;
 use alloy_primitives::{address, Address, Bytes};
 use core::fmt::Debug;
-use revm::context_interface::result::{ExecutionResult, ResultAndState};
+use revm::{
+    context_interface::result::{ExecutionResult, ResultAndState},
+    Database,
+};
 
 /// The [EIP-7685](https://eips.ethereum.org/EIPS/eip-7685) request type for EIP-8282 builder
 /// deposit requests.
@@ -45,6 +48,11 @@ pub const BUILDER_EXIT_REQUEST_PREDEPLOY_ADDRESS: Address =
 pub(crate) fn transact_builder_deposit_requests_contract_call<Halt>(
     evm: &mut impl Evm<HaltReason = Halt>,
 ) -> Result<ResultAndState<Halt>, BlockExecutionError> {
+    // The predeploy must exist: if there is no code at the address, the block is invalid.
+    ensure_contract_has_code(evm, BUILDER_DEPOSIT_REQUEST_PREDEPLOY_ADDRESS, |message| {
+        BlockValidationError::BuilderDepositRequestsContractCall { message }.into()
+    })?;
+
     // At the end of processing any execution block where Amsterdam is active, call the builder
     // deposit requests contract as `SYSTEM_ADDRESS` with empty calldata.
     match evm.transact_system_call(
@@ -67,6 +75,11 @@ pub(crate) fn transact_builder_deposit_requests_contract_call<Halt>(
 pub(crate) fn transact_builder_exit_requests_contract_call<Halt>(
     evm: &mut impl Evm<HaltReason = Halt>,
 ) -> Result<ResultAndState<Halt>, BlockExecutionError> {
+    // The predeploy must exist: if there is no code at the address, the block is invalid.
+    ensure_contract_has_code(evm, BUILDER_EXIT_REQUEST_PREDEPLOY_ADDRESS, |message| {
+        BlockValidationError::BuilderExitRequestsContractCall { message }.into()
+    })?;
+
     match evm.transact_system_call(
         SYSTEM_ADDRESS,
         BUILDER_EXIT_REQUEST_PREDEPLOY_ADDRESS,
@@ -120,6 +133,27 @@ pub(crate) fn exit_post_commit<Halt: Debug>(
                 message: format!("execution halted: {reason:?}"),
             }
             .into())
+        }
+    }
+}
+
+/// Returns an error built by `make_err` if the account at `address` has no code.
+///
+/// EIP-8282 follows the EIP-7002 deployment model: the system call is only defined for a
+/// deployed predeploy, and a block processed while the contract has no code is invalid.
+pub(crate) fn ensure_contract_has_code<Halt>(
+    evm: &mut impl Evm<HaltReason = Halt>,
+    address: Address,
+    make_err: impl FnOnce(alloc::string::String) -> BlockExecutionError,
+) -> Result<(), BlockExecutionError> {
+    match evm.db_mut().basic(address) {
+        Err(e) => Err(make_err(format!("database error: {e}"))),
+        Ok(account) => {
+            if account.is_some_and(|account| !account.is_empty_code_hash()) {
+                Ok(())
+            } else {
+                Err(make_err("contract has no code".to_string()))
+            }
         }
     }
 }


### PR DESCRIPTION
The EIP-7002/7251/8282 request contracts follow the deployment model where the system call is only defined for a deployed contract: a block processed while the predeploy has no code is invalid. Previously the system call to an empty account succeeded with empty output, so such blocks were only rejected indirectly via requests or BAL hash mismatches, or accepted outright.

Covers EEST's `SYSTEM_CONTRACT_EMPTY` deployment tests (`tests/prague/eip7002*`, `eip7251*` and `tests/amsterdam/eip8282*` `test_contract_deployment`), verified against the glamsterdam-devnet-8 hive eels/consume-engine suite with reth.