### PR TITLE
perf: avoid boxed account handles in EvmInternals storage ops

### DIFF
--- a/crates/evm/src/precompiles.rs
+++ b/crates/evm/src/precompiles.rs
@@ -1,6 +1,6 @@
 //! Helpers for dealing with Precompiles.
 
-use crate::{env::BlockEnvironment, Database, EvmInternals};
+use crate::{env::BlockEnvironment, traits::EvmInternalsImpl, Database, EvmInternals};
 use alloc::{
     borrow::Cow,
     boxed::Box,
@@ -572,6 +572,8 @@ where
         };
 
         let (block, tx, cfg, journaled_state, _, local) = context.all_mut();
+        // Keep the journal adapter on the stack so no allocation is needed per precompile call.
+        let mut internals = EvmInternalsImpl(journaled_state);
 
         let precompile_output = {
             let _span =
@@ -584,7 +586,7 @@ where
                 caller: inputs.caller,
                 value: inputs.call_value(),
                 is_static: inputs.is_static,
-                internals: EvmInternals::new(journaled_state, block, cfg, tx),
+                internals: EvmInternals::borrowed(&mut internals, block, cfg, tx),
                 target_address: inputs.target_address,
                 bytecode_address: inputs.bytecode_address,
             })
@@ -988,6 +990,7 @@ mod tests {
     use alloy_primitives::{address, Bytes};
     use revm::{
         context::{BlockEnv, TxEnv},
+        context_interface::journaled_state::JournalLoadError,
         database::EmptyDB,
         precompile::{PrecompileId, PrecompileOutput},
         primitives::hardfork::SpecId,
@@ -1078,6 +1081,31 @@ mod tests {
 
         assert!(internals.block_env_downcast_ref::<BlockEnv>().is_some());
         assert!(internals.tx_env_downcast_ref::<TxEnv>().is_some());
+    }
+
+    #[test]
+    fn test_evm_internals_storage_ops_skip_cold_load() {
+        let mut ctx = EthEvmContext::new(EmptyDB::default(), Default::default());
+        let mut internals = EvmInternals::from_context(&mut ctx);
+        let account = address!("0x00000000000000000000000000000000000000AA");
+        let key = U256::from(7);
+
+        let stored = internals
+            .sstore_skip_cold_load(account, key, U256::from(42), false)
+            .expect("sstore succeeds");
+        assert!(stored.is_cold);
+
+        let loaded = internals.sload_skip_cold_load(account, key, false).expect("sload succeeds");
+        assert_eq!(loaded.data, U256::from(42));
+        assert!(!loaded.is_cold);
+
+        // A cold slot cannot be read when the cold load is skipped.
+        let cold_key = U256::from(8);
+        assert!(matches!(
+            internals.sload_skip_cold_load(account, cold_key, true),
+            Err(JournalLoadError::ColdLoadSkipped)
+        ));
+        assert_eq!(internals.sload(account, cold_key).expect("sload succeeds").data, U256::ZERO);
     }
 
     #[test]

--- a/crates/evm/src/traits.rs
+++ b/crates/evm/src/traits.rs
@@ -252,7 +252,7 @@ where
 ///
 /// This trait provides an abstraction over journal operations without exposing
 /// associated types, making it object-safe and suitable for dynamic dispatch.
-trait EvmInternalsTr: Database<Error = ErasedError> + Debug {
+pub(crate) trait EvmInternalsTr: Database<Error = ErasedError> + Debug {
     fn load_account(&mut self, address: Address) -> Result<StateLoad<&Account>, EvmInternalsError>;
 
     fn load_account_mut_skip_cold_load<'a>(
@@ -319,10 +319,26 @@ trait EvmInternalsTr: Database<Error = ErasedError> + Debug {
         address: Address,
         key: StorageKey,
     ) -> Result<StateLoad<StorageValue>, EvmInternalsError> {
-        self.load_account_mut(address)?
-            .sload(key, false)
+        // safe to unwrap as skip_cold_load is false.
+        self.sload_skip_cold_load(address, key, false).map_err(JournalLoadError::unwrap_db_error)
+    }
+
+    /// Loads a storage slot, optionally skipping the slot's cold load.
+    ///
+    /// The account is always loaded, `skip_cold_load` only applies to the slot, exactly like
+    /// `load_account_mut(address)?.sload(key, skip_cold_load)`. Implementations should override
+    /// this to talk to the journal directly, the default goes through the boxed account handle.
+    fn sload_skip_cold_load(
+        &mut self,
+        address: Address,
+        key: StorageKey,
+        skip_cold_load: bool,
+    ) -> Result<StateLoad<StorageValue>, JournalLoadError<EvmInternalsError>> {
+        self.load_account_mut(address)
+            .map_err(JournalLoadError::DBError)?
+            .sload(key, skip_cold_load)
             .map(|i| i.map(|i| i.present_value()))
-            .map_err(|e| EvmInternalsError::database(e.unwrap_db_error()))
+            .map_err(|e| e.map(EvmInternalsError::database))
     }
 
     fn touch_account(&mut self, address: Address) -> Result<(), EvmInternalsError> {
@@ -359,9 +375,28 @@ trait EvmInternalsTr: Database<Error = ErasedError> + Debug {
         key: StorageKey,
         value: StorageValue,
     ) -> Result<StateLoad<SStoreResult>, EvmInternalsError> {
-        self.load_account_mut(address)?
-            .sstore(key, value, false)
-            .map_err(|e| EvmInternalsError::database(e.unwrap_db_error()))
+        // safe to unwrap as skip_cold_load is false.
+        self.sstore_skip_cold_load(address, key, value, false)
+            .map_err(JournalLoadError::unwrap_db_error)
+    }
+
+    /// Stores a storage value, optionally skipping the slot's cold load.
+    ///
+    /// The account is always loaded, `skip_cold_load` only applies to the slot, exactly like
+    /// `load_account_mut(address)?.sstore(key, value, skip_cold_load)`. Implementations should
+    /// override this to talk to the journal directly, the default goes through the boxed account
+    /// handle.
+    fn sstore_skip_cold_load(
+        &mut self,
+        address: Address,
+        key: StorageKey,
+        value: StorageValue,
+        skip_cold_load: bool,
+    ) -> Result<StateLoad<SStoreResult>, JournalLoadError<EvmInternalsError>> {
+        self.load_account_mut(address)
+            .map_err(JournalLoadError::DBError)?
+            .sstore(key, value, skip_cold_load)
+            .map_err(|e| e.map(EvmInternalsError::database))
     }
 
     fn log(&mut self, log: Log);
@@ -379,7 +414,7 @@ trait EvmInternalsTr: Database<Error = ErasedError> + Debug {
 
 /// Helper internal struct for implementing [`EvmInternals`].
 #[derive(Debug)]
-struct EvmInternalsImpl<'a, T>(&'a mut T);
+pub(crate) struct EvmInternalsImpl<'a, T>(pub(crate) &'a mut T);
 
 impl<T> revm::Database for EvmInternalsImpl<'_, T>
 where
@@ -432,6 +467,38 @@ where
             .map_err(|e| e.map(EvmInternalsError::database))
     }
 
+    fn sload_skip_cold_load(
+        &mut self,
+        address: Address,
+        key: StorageKey,
+        skip_cold_load: bool,
+    ) -> Result<StateLoad<StorageValue>, JournalLoadError<EvmInternalsError>> {
+        // Load through the concrete journaled account so no boxed handle is needed.
+        let mut account = self
+            .0
+            .load_account_mut(address)
+            .map_err(|e| JournalLoadError::DBError(EvmInternalsError::database(e)))?;
+        account
+            .sload(key, skip_cold_load)
+            .map(|i| i.map(|i| i.present_value()))
+            .map_err(|e| e.map(EvmInternalsError::database))
+    }
+
+    fn sstore_skip_cold_load(
+        &mut self,
+        address: Address,
+        key: StorageKey,
+        value: StorageValue,
+        skip_cold_load: bool,
+    ) -> Result<StateLoad<SStoreResult>, JournalLoadError<EvmInternalsError>> {
+        // Load through the concrete journaled account so no boxed handle is needed.
+        let mut account = self
+            .0
+            .load_account_mut(address)
+            .map_err(|e| JournalLoadError::DBError(EvmInternalsError::database(e)))?;
+        account.sstore(key, value, skip_cold_load).map_err(|e| e.map(EvmInternalsError::database))
+    }
+
     fn transfer(
         &mut self,
         from: Address,
@@ -466,9 +533,61 @@ where
     }
 }
 
+/// The journal access of [`EvmInternals`], either owned or borrowed from the caller's stack.
+///
+/// The borrowed variant lets the precompile runner avoid a heap allocation per precompile call.
+enum InternalsRef<'a> {
+    Owned(Box<dyn EvmInternalsTr + 'a>),
+    /// An exclusive borrow of an adapter owned by the caller.
+    ///
+    /// Held as a raw pointer instead of `&'a mut (dyn EvmInternalsTr + 'a)` so that
+    /// [`EvmInternals<'a>`] stays covariant in `'a`, exactly like the boxed variant.
+    Borrowed(core::ptr::NonNull<dyn EvmInternalsTr + 'a>, core::marker::PhantomData<&'a mut ()>),
+}
+
+impl<'a> InternalsRef<'a> {
+    /// Wraps an exclusive borrow of an adapter.
+    #[inline]
+    fn borrowed(internals: &'a mut (dyn EvmInternalsTr + 'a)) -> Self {
+        Self::Borrowed(core::ptr::NonNull::from(internals), core::marker::PhantomData)
+    }
+}
+
+impl<'a> core::ops::Deref for InternalsRef<'a> {
+    type Target = dyn EvmInternalsTr + 'a;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        match self {
+            Self::Owned(internals) => &**internals,
+            // SAFETY: the pointer was created from a `&'a mut` borrow that this value holds
+            // exclusively for its whole lifetime, and it is only ever dereferenced through
+            // `&self`/`&mut self`, which mirrors the original borrow's access rules.
+            Self::Borrowed(internals, _) => unsafe { internals.as_ref() },
+        }
+    }
+}
+
+impl core::ops::DerefMut for InternalsRef<'_> {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        match self {
+            Self::Owned(internals) => &mut **internals,
+            // SAFETY: see `Deref`, and `&mut self` guarantees no other reference exists.
+            Self::Borrowed(internals, _) => unsafe { internals.as_mut() },
+        }
+    }
+}
+
+impl Debug for InternalsRef<'_> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        Debug::fmt(&**self, f)
+    }
+}
+
 /// Helper type exposing hooks into EVM and access to evm internal settings.
 pub struct EvmInternals<'a> {
-    internals: Box<dyn EvmInternalsTr + 'a>,
+    internals: InternalsRef<'a>,
     block_env: &'a dyn BlockEnvironment,
     chain_id: u64,
     tx_origin: Address,
@@ -487,7 +606,24 @@ impl<'a> EvmInternals<'a> {
         T: JournalTr<Database: Database> + Debug,
     {
         Self {
-            internals: Box::new(EvmInternalsImpl(journal)),
+            internals: InternalsRef::Owned(Box::new(EvmInternalsImpl(journal))),
+            block_env,
+            chain_id: cfg_env.chain_id(),
+            tx_origin: tx_env.caller(),
+            tx_env,
+        }
+    }
+
+    /// Creates a new [`EvmInternals`] instance that borrows an already constructed journal
+    /// adapter instead of boxing one.
+    pub(crate) fn borrowed(
+        internals: &'a mut (dyn EvmInternalsTr + 'a),
+        block_env: &'a dyn BlockEnvironment,
+        cfg_env: &'a impl Cfg,
+        tx_env: &'a dyn TransactionTr,
+    ) -> Self {
+        Self {
+            internals: InternalsRef::borrowed(internals),
             block_env,
             chain_id: cfg_env.chain_id(),
             tx_origin: tx_env.caller(),
@@ -639,6 +775,17 @@ impl<'a> EvmInternals<'a> {
         self.internals.sload(address, key)
     }
 
+    /// Loads a storage slot, optionally skipping the slot's cold load; the account is always
+    /// loaded.
+    pub fn sload_skip_cold_load(
+        &mut self,
+        address: Address,
+        key: StorageKey,
+        skip_cold_load: bool,
+    ) -> Result<StateLoad<StorageValue>, JournalLoadError<EvmInternalsError>> {
+        self.internals.sload_skip_cold_load(address, key, skip_cold_load)
+    }
+
     /// Touches the account.
     ///
     /// This will load the account and return an error if database error occurs.
@@ -677,6 +824,18 @@ impl<'a> EvmInternals<'a> {
         value: StorageValue,
     ) -> Result<StateLoad<SStoreResult>, EvmInternalsError> {
         self.internals.sstore(address, key, value)
+    }
+
+    /// Stores a storage value, optionally skipping the slot's cold load; the account is always
+    /// loaded.
+    pub fn sstore_skip_cold_load(
+        &mut self,
+        address: Address,
+        key: StorageKey,
+        value: StorageValue,
+        skip_cold_load: bool,
+    ) -> Result<StateLoad<SStoreResult>, JournalLoadError<EvmInternalsError>> {
+        self.internals.sstore_skip_cold_load(address, key, value, skip_cold_load)
     }
 
     /// Logs the log in Journal state.


### PR DESCRIPTION
Every `sload`/`sstore` through `EvmInternals` went through `load_account_mut`, which boxes the journaled account into a `Box<dyn JournaledAccountTr>` just to perform one storage operation and drop it again. Precompiles that keep their state in the journal, such as the Tempo TIP-20 token, do six to ten of these per call, so the boxing dominates the per-operation cost. On top of that, `PrecompilesMap::run` boxed the journal adapter for every precompile invocation when constructing `EvmInternals`.

`EvmInternalsTr` gains `sload_skip_cold_load` and `sstore_skip_cold_load` with the same semantics as `load_account_mut(address)?.sload(key, skip_cold_load)`: the account is always loaded and `skip_cold_load` only applies to the slot. The existing `sload`/`sstore` are expressed through them, and the journal-backed implementation resolves the account through the concrete `JournaledAccount` instead of a boxed handle. The two methods are also exposed on `EvmInternals`, which callers that previously had to go through `load_account_mut` to pass `skip_cold_load` can use directly.

For the runner, `EvmInternals` now holds its journal access either owned or borrowed, and `PrecompilesMap::run` keeps the adapter on its stack and hands out the borrowed form. The borrowed variant is stored as a `NonNull` with a `PhantomData<&'a mut ()>` marker so `EvmInternals<'a>` keeps the covariance it had with the boxed field; the public API is unchanged.

Measured on Tempo's TIP-20 execution bench (4096 txgen transfers, counting allocator around jemalloc), together with #406: heap allocations drop from 98.0 to 69.0 per transaction.

Measured through Tempo (tempoxyz/tempo#7442, which adopts this PR together with #406 on a v0.38.0 backport): CI's CodSpeed report shows the txgen TIP-20 execution benchmark going from 142.2 ms to 137.3 ms (about 4%) and the DEX benchmarks improving by 5.5 to 7%, with heap allocations per transaction down from 98 to 69.

End-to-end on Tempo (tempoxyz/tempo#7442, derek e2e bench on Linux, two run pairs, adopting this PR together with #406): TPS +1.58% (12995 → 13200 tx/s, significant), block time P90 −2.9% and P99 −17%, validator-side gas throughput +2.5% and P99 −13%, all flagged significant by the harness; median block time unchanged.