### PR TITLE
feat: cheap contains and opt-in memoization for dynamic precompile lookups

### DIFF
--- a/crates/evm/src/precompiles.rs
+++ b/crates/evm/src/precompiles.rs
@@ -39,6 +39,8 @@ pub struct PrecompilesMap {
     precompiles: PrecompilesKind,
     /// An optional dynamic precompile loader that can lookup precompiles dynamically.
     lookup: Option<Box<dyn PrecompileLookup>>,
+    /// Memoized results of the dynamic lookup, see [`Self::enable_lookup_cache`].
+    lookup_cache: Option<AddressMap<DynPrecompile>>,
 }
 
 impl PrecompilesMap {
@@ -49,7 +51,11 @@ impl PrecompilesMap {
 
     /// Creates a new set of precompiles for a spec.
     pub fn new(precompiles: Cow<'static, Precompiles>) -> Self {
-        Self { precompiles: PrecompilesKind::Builtin(precompiles), lookup: None }
+        Self {
+            precompiles: PrecompilesKind::Builtin(precompiles),
+            lookup: None,
+            lookup_cache: None,
+        }
     }
 
     /// Maps a precompile at the given address using the provided function.
@@ -400,6 +406,34 @@ impl PrecompilesMap {
         L: PrecompileLookup + 'static,
     {
         self.lookup = Some(Box::new(lookup));
+        self.clear_lookup_cache();
+    }
+
+    /// Memoizes the precompiles returned by the dynamic lookup per address.
+    ///
+    /// Without the cache, the lookup function is invoked on every precompile execution for an
+    /// address it resolves, which makes lookups that construct a fresh [`DynPrecompile`] pay for
+    /// that construction on every call. With the cache enabled, the first execution of a
+    /// dynamically resolved precompile stores it in this map and later executions and
+    /// [`PrecompilesMap::get`] calls reuse it.
+    ///
+    /// Only enable this if the lookup returns equivalent precompiles for the same address for as
+    /// long as it is installed: the cache lives until the lookup is replaced through
+    /// [`Self::set_precompile_lookup`] or [`Self::map_precompile_lookup`].
+    ///
+    /// Cached precompiles are still treated as cold for gas accounting, exactly like uncached
+    /// lookup results, see [`PrecompileProvider::warm_addresses`].
+    pub fn enable_lookup_cache(&mut self) {
+        if self.lookup_cache.is_none() {
+            self.lookup_cache = Some(AddressMap::default());
+        }
+    }
+
+    /// Drops all memoized lookup results while keeping the cache enabled.
+    fn clear_lookup_cache(&mut self) {
+        if let Some(cache) = self.lookup_cache.as_mut() {
+            cache.clear();
+        }
     }
 
     /// Maps the dynamic precompile lookup function while preserving access to the previous lookup.
@@ -416,6 +450,7 @@ impl PrecompilesMap {
     {
         let previous = self.lookup.take();
         self.lookup = Some(Box::new(move |address: &Address| f(address, previous.as_deref())));
+        self.clear_lookup_cache();
     }
 
     /// Builder-style method to set a dynamic precompile lookup function.
@@ -523,9 +558,40 @@ impl PrecompilesMap {
             return Some(Either::Left(precompile));
         }
 
+        // Then reuse a memoized lookup result if the cache is enabled
+        if let Some(precompile) = self.lookup_cache.as_ref().and_then(|cache| cache.get(address)) {
+            return Some(Either::Left(Either::Right(precompile)));
+        }
+
         // Otherwise, try the lookup function if available
         let lookup = self.lookup.as_ref()?;
         lookup.lookup(address).map(Either::Right)
+    }
+
+    /// Returns whether the given address is a static precompile of this map.
+    fn contains_static(&self, address: &Address) -> bool {
+        match &self.precompiles {
+            PrecompilesKind::Builtin(precompiles) => precompiles.contains(address),
+            PrecompilesKind::Dynamic(dyn_precompiles) => {
+                dyn_precompiles.inner.contains_key(address)
+            }
+        }
+    }
+
+    /// Resolves the address through the dynamic lookup and memoizes the result if the cache is
+    /// enabled and the address is not a static precompile.
+    fn memoize_lookup(&mut self, address: &Address) {
+        if self.lookup_cache.is_none() || self.contains_static(address) {
+            return;
+        }
+        let Some(lookup) = self.lookup.as_ref() else { return };
+        let Some(cache) = self.lookup_cache.as_mut() else { return };
+        if cache.contains_key(address) {
+            return;
+        }
+        if let Some(precompile) = lookup.lookup(address) {
+            cache.insert(*address, precompile);
+        }
     }
 }
 
@@ -566,6 +632,8 @@ where
         context: &mut Context<BlockEnv, TxEnv, CfgEnv, DB, Journal<DB>, Chain>,
         inputs: &CallInputs,
     ) -> Result<Option<InterpreterResult>, String> {
+        self.memoize_lookup(&inputs.bytecode_address);
+
         // Get the precompile at the address
         let Some(precompile) = self.get(&inputs.bytecode_address) else {
             return Ok(None);
@@ -602,7 +670,9 @@ where
     }
 
     fn contains(&self, address: &Address) -> bool {
-        self.get(address).is_some()
+        self.contains_static(address)
+            || self.lookup_cache.as_ref().is_some_and(|cache| cache.contains_key(address))
+            || self.lookup.as_ref().is_some_and(|lookup| lookup.contains(address))
     }
 }
 
@@ -950,6 +1020,15 @@ pub trait PrecompileLookup {
     /// Returns `Some(precompile)` if a precompile exists at the address,
     /// or `None` if no precompile is found.
     fn lookup(&self, address: &Address) -> Option<DynPrecompile>;
+
+    /// Returns whether a precompile exists at the given address.
+    ///
+    /// The EVM asks this for every call target that is not a static precompile, so lookups that
+    /// construct a [`DynPrecompile`] should override this with a cheap check instead of relying on
+    /// the default, which resolves the precompile and discards it.
+    fn contains(&self, address: &Address) -> bool {
+        self.lookup(address).is_some()
+    }
 }
 
 /// Implement PrecompileLookup for closure types
@@ -1203,6 +1282,111 @@ mod tests {
         // Test non-matching address returns None
         let non_matching_address = address!("0x1234000000000000000000000000000000000001");
         assert!(spec_precompiles.get(&non_matching_address).is_none());
+    }
+
+    /// Lookup that counts how often it constructs a precompile and answers `contains` cheaply.
+    struct CountingLookup {
+        prefix: [u8; 2],
+        lookups: alloc::rc::Rc<core::cell::Cell<usize>>,
+    }
+
+    impl PrecompileLookup for CountingLookup {
+        fn lookup(&self, address: &Address) -> Option<DynPrecompile> {
+            if !self.contains(address) {
+                return None;
+            }
+            self.lookups.set(self.lookups.get() + 1);
+            Some(DynPrecompile::new(PrecompileId::Custom("dynamic".into()), |_input| {
+                Ok(PrecompileOutput::new(100, Bytes::from("dynamic precompile response"), 0))
+            }))
+        }
+
+        fn contains(&self, address: &Address) -> bool {
+            address.as_slice().starts_with(&self.prefix)
+        }
+    }
+
+    #[test]
+    fn test_precompile_lookup_contains_override() {
+        let mut spec_precompiles = PrecompilesMap::from(EthPrecompiles::new(SpecId::default()));
+        let lookups = alloc::rc::Rc::new(core::cell::Cell::new(0));
+        spec_precompiles.set_precompile_lookup(CountingLookup {
+            prefix: [0xDE, 0xAD],
+            lookups: lookups.clone(),
+        });
+
+        let dynamic_address = address!("0xDEAD000000000000000000000000000000000001");
+        let other_address = address!("0x1234000000000000000000000000000000000001");
+        let identity_address = address!("0x0000000000000000000000000000000000000004");
+
+        // `contains` uses the lookup's cheap check instead of constructing the precompile.
+        assert!(PrecompileProvider::<EthEvmContext<EmptyDB>>::contains(
+            &spec_precompiles,
+            &dynamic_address
+        ));
+        assert!(!PrecompileProvider::<EthEvmContext<EmptyDB>>::contains(
+            &spec_precompiles,
+            &other_address
+        ));
+        assert!(PrecompileProvider::<EthEvmContext<EmptyDB>>::contains(
+            &spec_precompiles,
+            &identity_address
+        ));
+        assert_eq!(lookups.get(), 0);
+
+        // `get` still resolves through the lookup.
+        assert!(spec_precompiles.get(&dynamic_address).is_some());
+        assert_eq!(lookups.get(), 1);
+    }
+
+    #[test]
+    fn test_lookup_cache_memoizes_dynamic_precompiles() {
+        let mut spec_precompiles = PrecompilesMap::from(EthPrecompiles::new(SpecId::default()));
+        let lookups = alloc::rc::Rc::new(core::cell::Cell::new(0));
+        spec_precompiles.set_precompile_lookup(CountingLookup {
+            prefix: [0xDE, 0xAD],
+            lookups: lookups.clone(),
+        });
+        spec_precompiles.enable_lookup_cache();
+
+        let dynamic_address = address!("0xDEAD000000000000000000000000000000000001");
+        let other_address = address!("0x1234000000000000000000000000000000000001");
+
+        // Without a memoized entry every `get` constructs the precompile again.
+        assert!(spec_precompiles.get(&dynamic_address).is_some());
+        assert!(spec_precompiles.get(&dynamic_address).is_some());
+        assert_eq!(lookups.get(), 2);
+
+        // Executing the precompile memoizes it, after which `get` and `contains` are free.
+        spec_precompiles.memoize_lookup(&dynamic_address);
+        assert_eq!(lookups.get(), 3);
+        spec_precompiles.memoize_lookup(&dynamic_address);
+        assert!(spec_precompiles.get(&dynamic_address).is_some());
+        assert!(spec_precompiles.get(&dynamic_address).is_some());
+        assert!(PrecompileProvider::<EthEvmContext<EmptyDB>>::contains(
+            &spec_precompiles,
+            &dynamic_address
+        ));
+        assert_eq!(lookups.get(), 3);
+
+        // Unknown addresses and static precompiles never enter the cache.
+        spec_precompiles.memoize_lookup(&other_address);
+        spec_precompiles.memoize_lookup(&address!("0x0000000000000000000000000000000000000004"));
+        assert!(spec_precompiles.get(&other_address).is_none());
+        assert_eq!(spec_precompiles.lookup_cache.as_ref().unwrap().len(), 1);
+
+        // Memoized precompiles stay cold for gas accounting.
+        assert!(!PrecompileProvider::<EthEvmContext<EmptyDB>>::warm_addresses(&spec_precompiles)
+            .contains(&dynamic_address));
+
+        // Replacing the lookup drops the memoized entries.
+        spec_precompiles.set_precompile_lookup(CountingLookup {
+            prefix: [0xDE, 0xAD],
+            lookups: lookups.clone(),
+        });
+        assert!(spec_precompiles.lookup_cache.as_ref().unwrap().is_empty());
+        assert!(spec_precompiles.get(&dynamic_address).is_some());
+        assert_eq!(lookups.get(), 4);
     }
 
     #[test]


### PR DESCRIPTION
`PrecompilesMap` resolves addresses that are not static precompiles through the `PrecompileLookup` on every check: `contains` is asked for every call target, and `run` asks again before executing. A lookup that builds a `DynPrecompile` for a family of addresses (Tempo's TIP-20 tokens, for example) therefore constructs a boxed precompile just to answer `contains`, and constructs it once more to run it, on every single call.

This adds `PrecompileLookup::contains` with a default that keeps the old behavior, so lookups can answer with a plain address check, and `PrecompilesMap::contains` uses it instead of resolving the precompile. It also adds an opt-in `enable_lookup_cache`: with the cache enabled, the first `run` of a dynamically resolved address memoizes the returned precompile and later `get`, `contains` and `run` calls reuse it. The cache is dropped whenever the lookup is replaced through `set_precompile_lookup` or `map_precompile_lookup`, memoized entries never enter `warm_addresses`, so gas accounting for dynamic precompiles is unchanged, and lookups that are not pure per address for the map's lifetime simply do not enable it.

Both behaviors are covered by unit tests using a counting lookup.

Measured through Tempo (tempoxyz/tempo#7442, which adopts this PR together with #405 on a v0.38.0 backport): CI's CodSpeed report shows the txgen TIP-20 execution benchmark going from 142.2 ms to 137.3 ms (about 4%) and the DEX benchmarks improving by 5.5 to 7%. A control with only this PR applied and Tempo's lookup unchanged is neutral on the same benchmark, so the gain comes from the cheap `contains` and the memoized lookups in the adopting code.

End-to-end on Tempo (tempoxyz/tempo#7442, derek e2e bench on Linux, two run pairs, adopting this PR together with #406): TPS +1.58% (12995 → 13200 tx/s, significant), block time P90 −2.9% and P99 −17%, validator-side gas throughput +2.5% and P99 −13%, all flagged significant by the harness; median block time unchanged.