### PR TITLE
fix: preserve changelog history during releases

### DIFF
--- a/scripts/changelog.sh
+++ b/scripts/changelog.sh
@@ -2,7 +2,7 @@
 set -e -o pipefail
 
 root=$(dirname "$(dirname "$0")")
-cmd=(git cliff --workdir "$root" --output "$root/CHANGELOG.md" "$@")
+cmd=(git cliff --repository "$root" --config "$root/cliff.toml" --output "$root/CHANGELOG.md" "$@")
 
 if [ "$DRY_RUN" = "true" ]; then
     echo "skipping due to dry run: ${cmd[*]}" >&2


### PR DESCRIPTION
Passing the workspace root through `--workdir` can leave git-cliff 2.13.1 with no commits, so the release hook writes an empty changelog. Use `--repository` to select the repository without implicit path filtering. Pass the config path explicitly so it does not depend on the caller’s directory.
